### PR TITLE
Add concurrency argument

### DIFF
--- a/bin/options.js
+++ b/bin/options.js
@@ -1,6 +1,7 @@
 const messages = require('./messages')
 const path = require('path')
 const yargs = require('yargs')
+const os = require('os')
 
 const OPTIONS = {
 
@@ -184,8 +185,12 @@ const OPTIONS = {
     group: 'Album options:',
     description: 'How albums are named in <date> mode [moment.js pattern]',
     'default': 'YYYY-MM'
+  },
+  'concurrency': {
+    description: 'Modify the concurrency of processing, if not set defaults to number of cores on system.',
+    type: 'number',
+    'default': os.cpus().length
   }
-
 }
 
 // explicity pass <process.argv> so we can unit test this logic
@@ -242,7 +247,8 @@ exports.get = (args) => {
     albumsOutputFolder: opts['albums-output-folder'],
     usageStats: opts['usage-stats'],
     log: opts['log'],
-    dryRun: opts['dry-run']
+    dryRun: opts['dry-run'],
+    concurrent: opts['concurrency']
   }
 }
 

--- a/bin/options.js
+++ b/bin/options.js
@@ -248,7 +248,7 @@ exports.get = (args) => {
     usageStats: opts['usage-stats'],
     log: opts['log'],
     dryRun: opts['dry-run'],
-    concurrent: opts['concurrency']
+    concurrencyOpt: opts['concurrency']
   }
 }
 

--- a/src/steps/step-process.js
+++ b/src/steps/step-process.js
@@ -11,7 +11,7 @@ exports.run = function (files, opts, parentTask) {
   // wrap each job in a Listr task that returns a Promise
   const tasks = jobs.map(job => listrTaskFromJob(job, opts.output))
   const listr = new ListrWorkQueue(tasks, {
-    concurrent: os.cpus().length,
+    concurrent: opts.concurrencyOpt,
     update: (done, total) => {
       const progress = done === total ? '' : `(${done}/${total})`
       parentTask.title = `Processing media ${progress}`

--- a/src/steps/step-process.js
+++ b/src/steps/step-process.js
@@ -3,7 +3,6 @@ const downsize = require('thumbsup-downsize')
 const fs = require('fs-extra')
 const info = require('debug')('thumbsup:info')
 const ListrWorkQueue = require('listr-work-queue')
-const os = require('os')
 const path = require('path')
 
 exports.run = function (files, opts, parentTask) {


### PR DESCRIPTION
- Currently thumbsup only processes using the number of cores available as concurrency thread count
- PR adds `--concurrency` argument that can modify to increase or decrease concurrency as wanted
- This is not a breaking change, there should be no customer impact.
