### PR TITLE
Fix behavior for non-traversable directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,18 @@
 # Node.js + build dependencies + runtime dependencies
 FROM thumbsupgallery/build:alpine
 
+# Switch to a non-root user
+# So we can test edge-cases around file permissions
+RUN adduser -D tester
+RUN chown -R tester:tester /app
+USER tester
+
 # Install and cache dependencies
-COPY package.json /app
+COPY --chown=tester package.json /app
 RUN npm install
 
+# Copy the entire source code
+COPY --chown=tester . /app
+
 # Run the tests
-COPY . /app
 RUN scripts/cibuild

--- a/src/components/index/glob.js
+++ b/src/components/index/glob.js
@@ -19,14 +19,7 @@ exports.find = function (rootFolder, callback) {
     sep: '/'
   })
   stream.on('data', stats => { entries[stats.path] = stats.mtime.getTime() })
-  stream.on('error', err => {
-    if (isEnoentCodeError(err)) {
-      warn(`File doesn't exist, skipping: ${err.path}`)
-      if (err.path === rootFolder) callback(null, {})
-    } else {
-      callback(err)
-    }
-  })
+  stream.on('error', err => warn(err.message))
   stream.on('end', () => callback(null, entries))
 }
 
@@ -39,8 +32,4 @@ function canTraverse (folder) {
     ignore: ['**/@eaDir', '#recycle']
   })
   return match.length > 0
-}
-
-function isEnoentCodeError (err) {
-  return err.code === 'ENOENT'
 }

--- a/test/components/index/glob.spec.js
+++ b/test/components/index/glob.spec.js
@@ -154,4 +154,24 @@ describe('Index: glob', function () {
       done()
     })
   })
+
+  it('ignores non-traversable directories', (done) => {
+    mock({
+      'media/secret': mock.directory({
+        mode: 0,
+        items: {
+          'IMG_0001.jpg': '...'
+        }
+      }),
+      'media/IMG_0002.jpg': '...'
+    })
+    glob.find('media', (err, map) => {
+      if (err) return done(err)
+      const keys = Object.keys(map).sort()
+      should(keys).eql([
+        'IMG_0002.jpg'
+      ])
+      done()
+    })
+  })
 })


### PR DESCRIPTION
Continuing the discussion from #107, this is the test for behavior with non-traversable directories.

Note that find returns an `EACCES` error (so the check for `ENOENT` does nothing and the test is failing currently), but also `done()` is apparently called twice. I have little experience with node, but should

    if (err) return done(err)

maybe be replaced by something like

    should(err).eql(null)

everywhere? I just copied that pattern.