### PR TITLE
Fixed EISDIR error on Windows with node 10.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "command-exists": "^1.2.6",
     "debug": "^3.1.0",
     "event-stream": "^3.3.4",
-    "fs-extra": "^6.0.1",
+    "fs-extra": "^7.0.0",
     "fs-readdir-recursive": "^1.0.0",
     "handlebars": "~4.0.5",
     "ini": "^1.3.4",


### PR DESCRIPTION
- What's the current behaviour?
Currently on windows (node 10.5.0) when the website is building I get a `EISDIR` error due to `fs.copy` trying to perform a `readlink` on a folder.
- What does the PR change?
This seems to be an issue with the `fs-extra` package which goes away when bumped to the latest version.
- Does it introduce a breaking change for existing users?
This should not introduce breaking changes unless from what I can see as the APIs the project uses should be compatible with the latest version