### PR TITLE
Use Slugify for Album names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4169,6 +4169,11 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
     },
+    "slugify": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.3.4.tgz",
+      "integrity": "sha512-KP0ZYk5hJNBS8/eIjGkFDCzGQIoZ1mnfQRYS5WM3273z+fxGWXeN0fkwf2ebEweydv9tioZIHGZKoF21U07/nw=="
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "moment": "^2.22.1",
     "readdir-enhanced": "^2.2.2",
     "resolve-pkg": "^1.0.0",
+    "slugify": "^1.3.4",
     "through2": "^3.0.0",
     "thumbsup-downsize": "^2.1.1",
     "url-join": "^4.0.0",

--- a/src/model/album.js
+++ b/src/model/album.js
@@ -9,6 +9,7 @@ A single photo/video could exist in multiple albums
 const _ = require('lodash')
 const path = require('path')
 const url = require('url')
+const slugify = require('slugify')
 var index = 0
 
 // number of images to show in the album preview grid
@@ -35,7 +36,7 @@ function Album (opts) {
   if (typeof opts === 'string') opts = { title: opts }
   this.id = opts.id || ++index
   this.title = opts.title || ('Album ' + this.id)
-  this.basename = sanitise(this.title)
+  this.basename = slugify(this.title)
   this.files = opts.files || []
   this.albums = opts.albums || []
   this.depth = 0
@@ -122,10 +123,6 @@ Album.prototype.pickPreviews = function () {
   for (var i = 0; i < missing; ++i) {
     this.previews.push(PREVIEW_MISSING)
   }
-}
-
-function sanitise (filename) {
-  return filename.replace(/[^a-z0-9-_]/ig, '')
 }
 
 function itemCount (count, type) {

--- a/test/integration/integration.spec.js
+++ b/test/integration/integration.spec.js
@@ -59,8 +59,8 @@ describe('Full integration', function () {
       assertExist(actualFiles, [
         'index.html',
         'london.html',
-        'newyork-day1.html',
-        'newyork-day2.html'
+        'newyork-day-1.html',
+        'newyork-day-2.html'
       ])
       // Thumbnails
       assertExist(actualFiles, [

--- a/test/model/album.spec.js
+++ b/test/model/album.spec.js
@@ -20,8 +20,8 @@ describe('Album', function () {
 
   describe('output paths', function () {
     it('sanitises album titles for the file name', function () {
-      const a = new Album('hello & world')
-      should(a.basename).eql('helloworld')
+      const a = new Album('& déjà vu')
+      should(a.basename).eql('and-deja-vu')
     })
 
     it('concatenates nested filenames for uniqueness', function () {


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!
Please describe what the change is below, and don't forget to check out the CONTRIBUTING guidelines.

-->

- What's the current behaviour?
Non-`0-9a-z` album names are sanitized to empty strings, which results in invalid `.html` album indexes.

- What does the PR change?
It replaces `sanitize` from `model/album` with [slugify](https://www.npmjs.com/package/slugify) which is able to handle various languages properly.

- Does it introduce a breaking change for existing users?
They will probably need to run thumbsup with `--cleanup` to get rid of redundant files.