### PR TITLE
Add in escaping of quotes for relative paths

### DIFF
--- a/src/website/theme-base/helpers/relative.js
+++ b/src/website/theme-base/helpers/relative.js
@@ -1,21 +1,21 @@
 const path = require('path')
 
 module.exports = (target, escape, options) => {
-    // Allow escape to be an optional parameter
-    if (typeof escape !== "boolean") {
-        options = escape;
-        escape = false;
-    }
+  // Allow escape to be an optional parameter
+  if (typeof escape !== 'boolean') {
+    options = escape
+    escape = false
+  }
 
-    const albumPath = options.data.root.album.path
-    var relative = path.relative(path.dirname(albumPath), target);
+  const albumPath = options.data.root.album.path
+  var relative = path.relative(path.dirname(albumPath), target)
 
-    // Escape single quotes
-    if (escape) {
-      var escaped = relative.replace(/\'/g, "%27");
-      escaped = escaped.replace(/\"/g, "%22");
-      return escaped;
-    } else {
-        return relative;
-    }
+  // Escape single quotes
+  if (escape) {
+    var escaped = relative.replace(/'/g, '%27')
+    escaped = escaped.replace(/"/g, '%22')
+    return escaped
+  } else {
+    return relative
+  }
 }

--- a/src/website/theme-base/helpers/relative.js
+++ b/src/website/theme-base/helpers/relative.js
@@ -1,6 +1,19 @@
 const path = require('path')
 
-module.exports = (target, options) => {
-  const albumPath = options.data.root.album.path
-  return path.relative(path.dirname(albumPath), target)
+module.exports = (target, escape, options) => {
+    // Allow escape to be an optional parameter
+    if (typeof escape !== "boolean") {
+        options = escape;
+        escape = false;
+    }
+
+    const albumPath = options.data.root.album.path
+    var relative = path.relative(path.dirname(albumPath), target);
+
+    // Escape single quotes
+    if (escape) {
+        return relative.replace(/\'/g, "%27");
+    } else {
+        return relative;
+    }
 }

--- a/src/website/theme-base/helpers/relative.js
+++ b/src/website/theme-base/helpers/relative.js
@@ -12,7 +12,9 @@ module.exports = (target, escape, options) => {
 
     // Escape single quotes
     if (escape) {
-        return relative.replace(/\'/g, "%27");
+      var escaped = relative.replace(/\'/g, "%27");
+      escaped = escaped.replace(/\"/g, "%22");
+      return escaped;
     } else {
         return relative;
     }

--- a/src/website/theme-base/helpers/relative.js
+++ b/src/website/theme-base/helpers/relative.js
@@ -1,21 +1,11 @@
 const path = require('path')
 
-module.exports = (target, escape, options) => {
-  // Allow escape to be an optional parameter
-  if (typeof escape !== 'boolean') {
-    options = escape
-    escape = false
-  }
-
+module.exports = (target, options) => {
   const albumPath = options.data.root.album.path
   var relative = path.relative(path.dirname(albumPath), target)
 
-  // Escape single quotes
-  if (escape) {
-    var escaped = relative.replace(/'/g, '%27')
-    escaped = escaped.replace(/"/g, '%22')
-    return escaped
-  } else {
-    return relative
-  }
+  // Escape single/double quotes
+  var escaped = relative.replace(/'/g, '%27')
+  escaped = escaped.replace(/"/g, '%22')
+  return escaped
 }


### PR DESCRIPTION
This change is a partial fix for issue #127. It allows for the relative path helper to escape single quotes as `%27`. There is also an update for the cards theme (which will be a separate PR).