### PR TITLE
Allow generating rectangular thumbnails

### DIFF
--- a/src/model/output.js
+++ b/src/model/output.js
@@ -15,7 +15,7 @@ exports.paths = function (filepath, mediaType, opts) {
 function image (filepath, opts) {
   return {
     thumbnail: relationship(filepath, 'photo:thumbnail', opts),
-    rectangularThumbnails: relationship(filepath, 'photo:rectangularThumbnails', opts),
+    rectangularThumbnail: relationship(filepath, 'photo:rectangularThumbnail', opts),
     large: relationship(filepath, shortRel('image', opts.photoPreview), opts),
     download: relationship(filepath, shortRel('image', opts.photoDownload), opts)
   }
@@ -24,7 +24,7 @@ function image (filepath, opts) {
 function video (filepath, opts) {
   return {
     thumbnail: relationship(filepath, 'video:thumbnail', opts),
-    rectangularThumbnails: relationship(filepath, 'video:rectangularThumbnails', opts),
+    rectangularThumbnail: relationship(filepath, 'video:rectangularThumbnail', opts),
     large: relationship(filepath, 'video:poster', opts),
     video: relationship(filepath, shortRel('video', opts.videoPreview), opts),
     download: relationship(filepath, shortRel('video', opts.videoDownload), opts)

--- a/src/model/output.js
+++ b/src/model/output.js
@@ -15,7 +15,7 @@ exports.paths = function (filepath, mediaType, opts) {
 function image (filepath, opts) {
   return {
     thumbnail: relationship(filepath, 'photo:thumbnail', opts),
-    thumbnailRectangular: relationship(filepath, 'photo:rectangularThumbnails', opts),
+    rectangularThumbnails: relationship(filepath, 'photo:rectangularThumbnails', opts),
     large: relationship(filepath, shortRel('image', opts.photoPreview), opts),
     download: relationship(filepath, shortRel('image', opts.photoDownload), opts)
   }
@@ -24,7 +24,7 @@ function image (filepath, opts) {
 function video (filepath, opts) {
   return {
     thumbnail: relationship(filepath, 'video:thumbnail', opts),
-    thumbnailRectangular: relationship(filepath, 'video:rectangularThumbnails', opts),
+    rectangularThumbnails: relationship(filepath, 'video:rectangularThumbnails', opts),
     large: relationship(filepath, 'video:poster', opts),
     video: relationship(filepath, shortRel('video', opts.videoPreview), opts),
     download: relationship(filepath, shortRel('video', opts.videoDownload), opts)

--- a/src/model/output.js
+++ b/src/model/output.js
@@ -15,7 +15,7 @@ exports.paths = function (filepath, mediaType, opts) {
 function image (filepath, opts) {
   return {
     thumbnail: relationship(filepath, 'photo:thumbnail', opts),
-    rectangularThumbnail: relationship(filepath, 'photo:rectangularThumbnail', opts),
+    small: relationship(filepath, 'photo:small', opts),
     large: relationship(filepath, shortRel('image', opts.photoPreview), opts),
     download: relationship(filepath, shortRel('image', opts.photoDownload), opts)
   }
@@ -24,7 +24,7 @@ function image (filepath, opts) {
 function video (filepath, opts) {
   return {
     thumbnail: relationship(filepath, 'video:thumbnail', opts),
-    rectangularThumbnail: relationship(filepath, 'video:rectangularThumbnail', opts),
+    small: relationship(filepath, 'video:small', opts),
     large: relationship(filepath, 'video:poster', opts),
     video: relationship(filepath, shortRel('video', opts.videoPreview), opts),
     download: relationship(filepath, shortRel('video', opts.videoDownload), opts)

--- a/src/model/output.js
+++ b/src/model/output.js
@@ -18,6 +18,7 @@ exports.paths = function (filepath, mediaType, opts) {
 function image (filepath, opts) {
   return {
     thumbnail: relationship(filepath, 'photo:thumbnail'),
+    thumbnailRectangular: relationship(filepath, 'photo:rectangularThumbnails'),
     large: relationship(filepath, shortRel('image', opts.photoPreview), opts),
     download: relationship(filepath, shortRel('image', opts.photoDownload), opts)
   }
@@ -26,6 +27,7 @@ function image (filepath, opts) {
 function video (filepath, opts) {
   return {
     thumbnail: relationship(filepath, 'video:thumbnail'),
+    thumbnailRectangular: relationship(filepath, 'video:rectangularThumbnails'),
     large: relationship(filepath, 'video:poster'),
     video: relationship(filepath, shortRel('video', opts.videoPreview), opts),
     download: relationship(filepath, shortRel('video', opts.videoDownload), opts)
@@ -53,8 +55,10 @@ function relationship (filepath, rel, options) {
 function pathForRelationship (filepath, rel, options) {
   switch (rel) {
     case 'photo:thumbnail': return 'media/thumbs/' + supportedPhotoFilename(filepath)
+    case 'photo:rectangularThumbnails': return 'media/thumbsRect/' + supportedPhotoFilename(filepath)
     case 'photo:large': return 'media/large/' + supportedPhotoFilename(filepath)
     case 'video:thumbnail': return 'media/thumbs/' + ext(filepath, 'jpg')
+    case 'video:rectangularThumbnails': return 'media/thumbsRect/' + ext(filepath, 'jpg')
     case 'video:poster': return 'media/large/' + ext(filepath, 'jpg')
     case 'video:resized': return 'media/large/' + ext(filepath, options.videoFormat)
     case 'fs:copy': return path.join('media', 'original', filepath)

--- a/src/model/structure.js
+++ b/src/model/structure.js
@@ -11,8 +11,10 @@ exports.folders = function (filepath, rel, options = {}) {
   const videoExt = options.videoFormat || 'mp4'
   switch (rel) {
     case 'photo:thumbnail': return `media/thumbs/${dir}/${name}.${photoExt}`
+    case 'photo:rectangularThumbnails': return `media/thumbsRect/${dir}/${name}.${photoExt}`
     case 'photo:large': return `media/large/${dir}/${name}.${photoExt}`
     case 'video:thumbnail': return `media/thumbs/${dir}/${name}.jpg`
+    case 'video:rectangularThumbnails': return `media/thumbsRect/${dir}/${name}.jpg`
     case 'video:poster': return `media/large/${dir}/${name}.jpg`
     case 'video:resized': return `media/large/${dir}/${name}.${videoExt}`
     case 'fs:copy': return `media/original/${dir}/${name}.${ext}`
@@ -30,8 +32,10 @@ exports.suffix = function (filepath, rel, options = {}) {
   const videoExt = options.videoFormat || 'mp4'
   switch (rel) {
     case 'photo:thumbnail': return `media/${dir}/${name}_${ext}_thumb.${photoExt}`
+    case 'photo:Rectangularhumbnails': return `media/${dir}/${name}_${ext}_thumb_rect.${photoExt}`
     case 'photo:large': return `media/${dir}/${name}_${ext}_large.${photoExt}`
     case 'video:thumbnail': return `media/${dir}/${name}_${ext}_thumb.jpg`
+    case 'video:Rectangularhumbnails': return `media/${dir}/${name}_${ext}_thumb_rect.jpg`
     case 'video:poster': return `media/${dir}/${name}_${ext}_poster.jpg`
     case 'video:resized': return `media/${dir}/${name}_${ext}_large.${videoExt}`
     case 'fs:copy': return `media/${dir}/${name}.${ext}`

--- a/src/model/structure.js
+++ b/src/model/structure.js
@@ -11,10 +11,10 @@ exports.folders = function (filepath, rel, options = {}) {
   const videoExt = options.videoFormat || 'mp4'
   switch (rel) {
     case 'photo:thumbnail': return `media/thumbs/${dir}/${name}.${photoExt}`
-    case 'photo:rectangularThumbnail': return `media/thumbsRect/${dir}/${name}.${photoExt}`
+    case 'photo:small': return `media/small/${dir}/${name}.${photoExt}`
     case 'photo:large': return `media/large/${dir}/${name}.${photoExt}`
     case 'video:thumbnail': return `media/thumbs/${dir}/${name}.jpg`
-    case 'video:rectangularThumbnail': return `media/thumbsRect/${dir}/${name}.jpg`
+    case 'video:small': return `media/small/${dir}/${name}.jpg`
     case 'video:poster': return `media/large/${dir}/${name}.jpg`
     case 'video:resized': return `media/large/${dir}/${name}.${videoExt}`
     case 'fs:copy': return `media/original/${dir}/${name}.${ext}`
@@ -32,10 +32,10 @@ exports.suffix = function (filepath, rel, options = {}) {
   const videoExt = options.videoFormat || 'mp4'
   switch (rel) {
     case 'photo:thumbnail': return `media/${dir}/${name}_${ext}_thumb.${photoExt}`
-    case 'photo:Rectangularhumbnail': return `media/${dir}/${name}_${ext}_thumb_rect.${photoExt}`
+    case 'photo:small': return `media/${dir}/${name}_${ext}_small.${photoExt}`
     case 'photo:large': return `media/${dir}/${name}_${ext}_large.${photoExt}`
     case 'video:thumbnail': return `media/${dir}/${name}_${ext}_thumb.jpg`
-    case 'video:Rectangularhumbnail': return `media/${dir}/${name}_${ext}_thumb_rect.jpg`
+    case 'video:small': return `media/${dir}/${name}_${ext}_small.jpg`
     case 'video:poster': return `media/${dir}/${name}_${ext}_poster.jpg`
     case 'video:resized': return `media/${dir}/${name}_${ext}_large.${videoExt}`
     case 'fs:copy': return `media/${dir}/${name}.${ext}`

--- a/src/model/structure.js
+++ b/src/model/structure.js
@@ -11,10 +11,10 @@ exports.folders = function (filepath, rel, options = {}) {
   const videoExt = options.videoFormat || 'mp4'
   switch (rel) {
     case 'photo:thumbnail': return `media/thumbs/${dir}/${name}.${photoExt}`
-    case 'photo:rectangularThumbnails': return `media/thumbsRect/${dir}/${name}.${photoExt}`
+    case 'photo:rectangularThumbnail': return `media/thumbsRect/${dir}/${name}.${photoExt}`
     case 'photo:large': return `media/large/${dir}/${name}.${photoExt}`
     case 'video:thumbnail': return `media/thumbs/${dir}/${name}.jpg`
-    case 'video:rectangularThumbnails': return `media/thumbsRect/${dir}/${name}.jpg`
+    case 'video:rectangularThumbnail': return `media/thumbsRect/${dir}/${name}.jpg`
     case 'video:poster': return `media/large/${dir}/${name}.jpg`
     case 'video:resized': return `media/large/${dir}/${name}.${videoExt}`
     case 'fs:copy': return `media/original/${dir}/${name}.${ext}`
@@ -32,10 +32,10 @@ exports.suffix = function (filepath, rel, options = {}) {
   const videoExt = options.videoFormat || 'mp4'
   switch (rel) {
     case 'photo:thumbnail': return `media/${dir}/${name}_${ext}_thumb.${photoExt}`
-    case 'photo:Rectangularhumbnails': return `media/${dir}/${name}_${ext}_thumb_rect.${photoExt}`
+    case 'photo:Rectangularhumbnail': return `media/${dir}/${name}_${ext}_thumb_rect.${photoExt}`
     case 'photo:large': return `media/${dir}/${name}_${ext}_large.${photoExt}`
     case 'video:thumbnail': return `media/${dir}/${name}_${ext}_thumb.jpg`
-    case 'video:Rectangularhumbnails': return `media/${dir}/${name}_${ext}_thumb_rect.jpg`
+    case 'video:Rectangularhumbnail': return `media/${dir}/${name}_${ext}_thumb_rect.jpg`
     case 'video:poster': return `media/${dir}/${name}_${ext}_poster.jpg`
     case 'video:resized': return `media/${dir}/${name}_${ext}_large.${videoExt}`
     case 'fs:copy': return `media/${dir}/${name}.${ext}`

--- a/src/steps/actions.js
+++ b/src/steps/actions.js
@@ -20,7 +20,7 @@ exports.createMap = function (opts) {
     height: thumbSize,
     width: thumbSize
   })
-  const rectangularThumbnails = Object.assign({}, defaultOptions, {
+  const rectangularThumbnail = Object.assign({}, defaultOptions, {
     height: thumbSize
   })
   const large = Object.assign({}, defaultOptions, {
@@ -44,9 +44,9 @@ exports.createMap = function (opts) {
     'video:resized': (task, done) => downsize.video(task.src, task.dest, videoOpts, done)
   }
 
-  if (themeOpts.rectangularThumbnails) {
-    actions['photo:rectangularThumbnails'] = (task, done) => downsize.image(task.src, task.dest, rectangularThumbnails, done)
-    actions['video:rectangularThumbnails'] = (task, done) => downsize.still(task.src, task.dest, rectangularThumbnails, done)
+  if (themeOpts.rectangularThumbnail) {
+    actions['photo:rectangularThumbnail'] = (task, done) => downsize.image(task.src, task.dest, rectangularThumbnail, done)
+    actions['video:rectangularThumbnail'] = (task, done) => downsize.still(task.src, task.dest, rectangularThumbnail, done)
   }
 
   return actions

--- a/src/steps/actions.js
+++ b/src/steps/actions.js
@@ -3,6 +3,7 @@ const fs = require('fs-extra')
 
 exports.createMap = function (opts) {
   const thumbSize = opts.thumbSize || 120
+  const smallSize = 300
   const largeSize = opts.largeSize || 1000
   const defaultOptions = {
     quality: opts.photoQuality,
@@ -17,7 +18,7 @@ exports.createMap = function (opts) {
     width: thumbSize
   })
   const small = Object.assign({}, defaultOptions, {
-    height: thumbSize
+    height: smallSize
   })
   const large = Object.assign({}, defaultOptions, {
     height: largeSize,
@@ -38,6 +39,6 @@ exports.createMap = function (opts) {
     'video:thumbnail': (task, done) => downsize.still(task.src, task.dest, thumbnail, done),
     'video:small': (task, done) => downsize.still(task.src, task.dest, small, done),
     'video:poster': (task, done) => downsize.still(task.src, task.dest, large, done),
-    'video:resized': (task, done) => downsize.video(task.src, task.dest, videoOpts, done),
+    'video:resized': (task, done) => downsize.video(task.src, task.dest, videoOpts, done)
   }
 }

--- a/src/steps/actions.js
+++ b/src/steps/actions.js
@@ -2,8 +2,6 @@ const downsize = require('thumbsup-downsize')
 const fs = require('fs-extra')
 
 exports.createMap = function (opts) {
-  const themeDir = opts.themePath || localThemePath(opts.theme)
-
   const thumbSize = opts.thumbSize || 120
   const largeSize = opts.largeSize || 1000
   const defaultOptions = {
@@ -32,7 +30,7 @@ exports.createMap = function (opts) {
     bitrate: opts.videoBitrate
   }
 
-  let actions = {
+  return {
     'fs:copy': (task, done) => fs.copy(task.src, task.dest, done),
     'fs:symlink': (task, done) => fs.symlink(task.src, task.dest, done),
     'photo:thumbnail': (task, done) => downsize.image(task.src, task.dest, thumbnail, done),
@@ -43,6 +41,4 @@ exports.createMap = function (opts) {
     'video:poster': (task, done) => downsize.still(task.src, task.dest, large, done),
     'video:resized': (task, done) => downsize.video(task.src, task.dest, videoOpts, done),
   }
-
-  return actions
 }

--- a/src/steps/actions.js
+++ b/src/steps/actions.js
@@ -29,7 +29,6 @@ exports.createMap = function (opts) {
     quality: opts.videoQuality,
     bitrate: opts.videoBitrate
   }
-
   return {
     'fs:copy': (task, done) => fs.copy(task.src, task.dest, done),
     'fs:symlink': (task, done) => fs.symlink(task.src, task.dest, done),

--- a/src/steps/actions.js
+++ b/src/steps/actions.js
@@ -1,12 +1,10 @@
 const downsize = require('thumbsup-downsize')
 const fs = require('fs-extra')
-const Theme = require('../website/theme')
 
 exports.createMap = function (opts) {
   const themeDir = opts.themePath || localThemePath(opts.theme)
-  const themeOpts = new Theme(themeDir, opts.output).loadPackageOptions()
 
-  const thumbSize = Math.max(opts.thumbSize || 120, themeOpts.defaultThumbnailSize || 120)
+  const thumbSize = opts.thumbSize || 120
   const largeSize = opts.largeSize || 1000
   const defaultOptions = {
     quality: opts.photoQuality,
@@ -20,7 +18,7 @@ exports.createMap = function (opts) {
     height: thumbSize,
     width: thumbSize
   })
-  const rectangularThumbnail = Object.assign({}, defaultOptions, {
+  const small = Object.assign({}, defaultOptions, {
     height: thumbSize
   })
   const large = Object.assign({}, defaultOptions, {
@@ -38,15 +36,12 @@ exports.createMap = function (opts) {
     'fs:copy': (task, done) => fs.copy(task.src, task.dest, done),
     'fs:symlink': (task, done) => fs.symlink(task.src, task.dest, done),
     'photo:thumbnail': (task, done) => downsize.image(task.src, task.dest, thumbnail, done),
+    'photo:small': (task, done) => downsize.image(task.src, task.dest, small, done),
     'photo:large': (task, done) => downsize.image(task.src, task.dest, large, done),
     'video:thumbnail': (task, done) => downsize.still(task.src, task.dest, thumbnail, done),
+    'video:small': (task, done) => downsize.still(task.src, task.dest, small, done),
     'video:poster': (task, done) => downsize.still(task.src, task.dest, large, done),
-    'video:resized': (task, done) => downsize.video(task.src, task.dest, videoOpts, done)
-  }
-
-  if (themeOpts.rectangularThumbnail) {
-    actions['photo:rectangularThumbnail'] = (task, done) => downsize.image(task.src, task.dest, rectangularThumbnail, done)
-    actions['video:rectangularThumbnail'] = (task, done) => downsize.still(task.src, task.dest, rectangularThumbnail, done)
+    'video:resized': (task, done) => downsize.video(task.src, task.dest, videoOpts, done),
   }
 
   return actions

--- a/src/website/theme-base/helpers/compare.js
+++ b/src/website/theme-base/helpers/compare.js
@@ -18,7 +18,9 @@ const operators = {
   '<':   function (l, r) { return l < r   },
   '>':   function (l, r) { return l > r   },
   '<=':  function (l, r) { return l <= r  },
-  '>=':  function (l, r) { return l >= r  }
+  '>=':  function (l, r) { return l >= r  },
+  '||':  function (l, r) { return l || r  },
+  '&&':  function (l, r) { return l && r  }
 }
 /* eslint-enable */
 


### PR DESCRIPTION
This PR adds in rectangular thumbnail generation and specifying more thumbnail sizes. This is part of the solution for #86. I am using the `package.json` options to allow for themes to specify custom min thumbnail dimensions as well as generating rectangular (correct aspect) thumbnails.

Here is the relevant section of an updated `package.json` that has the new options.
```
"thumbsup": {
  "themeRoot": "theme",
  "rectangularThumbnail": true,
  "defaultThumbnailSize": 250
}
```

If the new options are not specified, nothing changes for album generation.