### PR TITLE
Allow reading movie caption from QuickTime Title, when available

### DIFF
--- a/src/model/metadata.js
+++ b/src/model/metadata.js
@@ -83,7 +83,8 @@ function caption (exif, picasa) {
          tagValue(exif, 'IPTC', 'Headline') ||
          tagValue(exif, 'XMP', 'Description') ||
          tagValue(exif, 'XMP', 'Title') ||
-         tagValue(exif, 'XMP', 'Label')
+         tagValue(exif, 'XMP', 'Label') ||
+         tagValue(exif, 'QuickTime', 'Title')
 }
 
 function keywords (exif, picasa) {


### PR DESCRIPTION
`docker build -f Dockerfile.test .` passes, though there isn't a `.mov` test fixture.