### PR TITLE
Generate SEO files (robots.txt and sitemap.xml)

### DIFF
--- a/bin/options.js
+++ b/bin/options.js
@@ -280,6 +280,12 @@ const OPTIONS = {
     type: 'string',
     'default': 'en'
   },
+  'seo-location': {
+    group: 'Website options:',
+    description: 'Location where the site will be hosted. If provided, sitemap.xml and robots.txt will be created.',
+    type: 'string',
+    'default': null
+  },
 
   // ------------------------------------
   // Misc options

--- a/src/website/website.js
+++ b/src/website/website.js
@@ -93,8 +93,7 @@ function outputSEO (output, seoLocation, rootAlbum) {
 
   // Generate robots.txt
   const robotsTxt = 'User-Agent: *\nDisallow:\n\nSitemap: ' + seoPrefix + 'sitemap.xml\n'
-  fs.writeFile(path.join(output, 'robots.txt'), robotsTxt, () => {
-  })
+  fs.writeFileSync(path.join(output, 'robots.txt'), robotsTxt)
 
   // Generate sitemap
   let sitemapXML = '<?xml version="1.0" encoding="UTF-8"?>\n' +
@@ -114,6 +113,5 @@ function outputSEO (output, seoLocation, rootAlbum) {
   addToSitemap(rootAlbum)
 
   sitemapXML += '</urlset>\n'
-  fs.writeFile(path.join(output, 'sitemap.xml'), sitemapXML, () => {
-  })
+  fs.writeFileSync(path.join(output, 'sitemap.xml'), sitemapXML)
 }

--- a/src/website/website.js
+++ b/src/website/website.js
@@ -40,6 +40,8 @@ exports.build = function (rootAlbum, opts, callback) {
     next => theme.prepare(next),
     next => async.parallel(tasks, next)
   ], callback)
+
+  outputSEO(opts.output, opts.seoLocation, rootAlbum)
 }
 
 function createRenderingTasks (theme, templateData, currentAlbum, breadcrumbs) {
@@ -78,4 +80,40 @@ function readThemeSettings (filepath) {
   } catch (ex) {
     throw new Error('Failed to parse JSON theme settings file: ' + filepath)
   }
+}
+
+function outputSEO (output, seoLocation, rootAlbum) {
+  // SEO (sitemap and robots.txt)
+  if (!seoLocation) {
+    return
+  }
+
+  // Guaranteed to end with slash
+  const seoPrefix = seoLocation + (seoLocation.endsWith('/') ? '' : '/')
+
+  // Generate robots.txt
+  const robotsTxt = 'User-Agent: *\nDisallow:\n\nSitemap: ' + seoPrefix + 'sitemap.xml\n'
+  fs.writeFile(path.join(output, 'robots.txt'), robotsTxt, () => {
+  })
+
+  // Generate sitemap
+  let sitemapXML = '<?xml version="1.0" encoding="UTF-8"?>\n' +
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+  const now = new Date().toISOString()
+
+  function addToSitemap (album) {
+    sitemapXML +=
+      '    <url>\n' +
+      '        <loc>' + seoPrefix + album.url + '</loc>\n' +
+      '        <lastmod>' + now + '</lastmod>\n' +
+      '    </url>\n'
+
+    album.albums.forEach((subAlbum) => addToSitemap(subAlbum))
+  }
+
+  addToSitemap(rootAlbum)
+
+  sitemapXML += '</urlset>\n'
+  fs.writeFile(path.join(output, 'sitemap.xml'), sitemapXML, () => {
+  })
 }


### PR DESCRIPTION
**What's the current behaviour?**
No generation of robots.txt or sitemap

**What does the PR change?**
Generates an XML sitemap read by search engine crawlers and a robots.txt directing them to it.

**Does it introduce a breaking change for existing users?**
No, just add `seo-location` to the config to opt-in to this feature.

**Example config:**
`--seo-location https://example.com/gallery`

**Example robots.txt output:**
```
User-Agent: *
Disallow:

Sitemap: https://example.com/sitemap.xml
```

**Example sitemap.xml output:**
```
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
    <url>
        <loc>https://example.com/index.html</loc>
        <lastmod>2020-05-02T22:24:42.219Z</lastmod>
    </url>
    <url>
        <loc>https://example.com/Album.html</loc>
        <lastmod>2020-05-02T22:24:42.219Z</lastmod>
    </url>
    ...
</urlset>
```