### PR TITLE
Show media names without the extension

### DIFF
--- a/src/model/file.js
+++ b/src/model/file.js
@@ -19,7 +19,7 @@ class File {
   constructor (dbEntry, meta, opts) {
     this.id = ++index
     this.path = dbEntry.SourceFile
-    this.filename = path.basename(dbEntry.SourceFile)
+    this.filename = path.basename(dbEntry.SourceFile, path.extname(dbEntry.SourceFile))
     this.date = fileDate(dbEntry)
     this.type = mediaType(dbEntry)
     this.isVideo = (this.type === 'video')


### PR DESCRIPTION
**What's the current behaviour?**

![image](https://user-images.githubusercontent.com/1693960/81636009-55cdef80-93d8-11ea-9b86-55070ce443ad.png)

![image](https://user-images.githubusercontent.com/1693960/81636210-e0165380-93d8-11ea-8dab-ea8c6f32b596.png)

**What does the PR change?**

![image](https://user-images.githubusercontent.com/1693960/81636025-5bc3d080-93d8-11ea-8d67-1a16c64832cc.png)

![image](https://user-images.githubusercontent.com/1693960/81636197-d856af00-93d8-11ea-820a-210f50d5c186.png)

**Does it introduce a breaking change for existing users?**

Only if they rely on `File.filename` containing the extension.

This does not break navigation (tested with `theme-flow`)
