### PR TITLE
feat(cli): option to set small size

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Input options:
 
 Output options:
   --thumb-size          Pixel size of the square thumbnails  [number] [default: 120]
+  --small-size          Pixel height of the small photos  [number] [default: 300]
   --large-size          Pixel height of the fullscreen photos  [number] [default: 1000]
   --photo-quality       Quality of the resized/converted photos  [number] [default: 90]
   --video-quality       Quality of the converted video (percent)  [number] [default: 75]

--- a/bin/options.js
+++ b/bin/options.js
@@ -67,6 +67,12 @@ const OPTIONS = {
     type: 'number',
     'default': 120
   },
+  'small-size': {
+    group: 'Output options:',
+    description: 'Pixel height of the small photos',
+    type: 'number',
+    'default': 300
+  },
   'large-size': {
     group: 'Output options:',
     description: 'Pixel height of the fullscreen photos',

--- a/src/steps/actions.js
+++ b/src/steps/actions.js
@@ -3,7 +3,7 @@ const fs = require('fs-extra')
 
 exports.createMap = function (opts) {
   const thumbSize = opts.thumbSize || 120
-  const smallSize = 300
+  const smallSize = opts.smallSize || 300
   const largeSize = opts.largeSize || 1000
   const defaultOptions = {
     quality: opts.photoQuality,

--- a/test/steps/actions.spec.js
+++ b/test/steps/actions.spec.js
@@ -74,6 +74,17 @@ describe('actions', () => {
     })
   })
 
+  it('photo:small = creates a small image', testEnd => {
+    const map = actions.createMap({ smallSize: 300 })
+    const action = map['photo:small']
+    action(ANY_TASK, err => {
+      should(err).eql(null)
+      const downsizeArgs = shouldCallDownsize(downsize.image)
+      should(downsizeArgs).property('height', 300)
+      testEnd()
+    })
+  })
+
   it('photo:large = creates a large image', testEnd => {
     const map = actions.createMap({ largeSize: 1000 })
     const action = map['photo:large']

--- a/test/steps/step-cleanup.spec.js
+++ b/test/steps/step-cleanup.spec.js
@@ -26,6 +26,8 @@ describe('Steps: cleanup', () => {
     mock({
       'output/media/thumbs/paris/IMG_0001.jpg': '',
       'output/media/thumbs/london/IMG_0002.jpg': '',
+      'output/media/small/paris/IMG_0001.jpg': '',
+      'output/media/small/london/IMG_0002.jpg': '',
       'output/media/large/paris/IMG_0001.jpg': '',
       'output/media/large/london/IMG_0002.jpg': ''
     })


### PR DESCRIPTION
**Current**

The height of small photos is hard coded to 300px with no way to override it.

**Changes**

Now option `small-size` allows specify the small size. Unit tests have also been done for the "small" feature.

**Breaking changes**

None.
