### PR TITLE
Don't duplicate photos in the same album

### DIFF
--- a/src/input/hierarchy.js
+++ b/src/input/hierarchy.js
@@ -1,3 +1,4 @@
+const _ = require('lodash')
 const path = require('path')
 const Album = require('../model/album')
 
@@ -21,11 +22,13 @@ function group (collection, mapper, homeAlbumName) {
   // put all files in the right albums
   // a file can be in multiple albums
   collection.forEach(function (file) {
-    const albums = mapper.getAlbums(file)
+    const albums = _.chain(mapper.getAlbums(file))
+      // All special names map to the same home
+      .map(albumPath => !albumPath || ['', '.', '/'].includes(albumPath) ? '.' : albumPath)
+      // no duplicate albums
+      .uniq()
+      .value()
     albums.forEach(albumPath => {
-      if (!albumPath || albumPath === '/') {
-        albumPath = '.'
-      }
       createAlbumHierarchy(groups, albumPath)
       groups[albumPath].files.push(file)
     })

--- a/test/input/hierarchy.spec.js
+++ b/test/input/hierarchy.spec.js
@@ -112,6 +112,32 @@ describe('hierarchy', function () {
       should(home.albums[0].albums[0].title).eql('two')
       should(home.albums[0].albums[0].files).eql([files[1]])
     })
+
+    it('does not duplicate home album', function () {
+      const files = [
+        fixtures.photo({ path: 'one/IMG_000001.jpg' })
+      ]
+      const mapper = mockMapper(file => ['.', '/', path.dirname(file.path)])
+      const home = hierarchy.createAlbums(files, mapper, DEFAULT_OPTS)
+      should(home.files.length).eql(1)
+      should(home.files[0].filename).eql(files[0].filename)
+      should(home.albums.length).eql(1)
+      should(home.albums[0].title).eql('one')
+      should(home.albums[0].files).eql(files)
+      should(home.albums[0].albums.length).eql(0)
+    })
+
+    it('does not duplicate sub albums', function () {
+      const files = [
+        fixtures.photo({ path: 'one/IMG_000001.jpg' })
+      ]
+      const mapper = mockMapper(file => ['one', path.dirname(file.path)])
+      const home = hierarchy.createAlbums(files, mapper, DEFAULT_OPTS)
+      should(home.albums.length).eql(1)
+      should(home.albums[0].title).eql('one')
+      should(home.albums[0].files).eql(files)
+      should(home.albums[0].albums.length).eql(0)
+    })
   })
 })
 


### PR DESCRIPTION
A file can be in multiple albums, but the same file can't be in the same album multiple times. This can happen in multiple cases, for instance:

- If one of the mapping for the album contains "/"
- If a file is stored under "sub/file.jpg", one of the mapping is "%path" and the other is "sub"

Fixes #220 