### PR TITLE
Support albums and images with # or ?

### DIFF
--- a/src/model/album.js
+++ b/src/model/album.js
@@ -8,7 +8,6 @@ A single photo/video could exist in multiple albums
 
 const _ = require('lodash')
 const path = require('path')
-const url = require('url')
 const slugify = require('slugify')
 var index = 0
 

--- a/src/model/album.js
+++ b/src/model/album.js
@@ -59,7 +59,7 @@ Album.prototype.finalize = function (options, parent) {
       this.basename = parent.basename + '-' + this.basename
     }
     this.path = path.join(albumsOutputFolder, this.basename + '.html')
-    this.url = this.getUrl(albumsOutputFolder, this.basename + '.html');
+    this.url = this.getUrl(albumsOutputFolder, this.basename + '.html')
     this.depth = parent.depth + 1
   }
   // path to the optional ZIP file
@@ -119,7 +119,7 @@ Album.prototype.getUrl = function (albumsOutputFolder, documentPath) {
   if (url.startsWith('./')) {
     url = url.slice(2)
   }
-  return url;
+  return url
 }
 
 Album.prototype.sort = function (options) {

--- a/src/model/album.js
+++ b/src/model/album.js
@@ -60,7 +60,7 @@ Album.prototype.finalize = function (options, parent) {
       this.basename = parent.basename + '-' + this.basename
     }
     this.path = path.join(albumsOutputFolder, this.basename + '.html')
-    this.url = url.resolve(albumsOutputFolder + '/', encodeURIComponent(this.basename) + '.html')
+    this.url = encodeURIComponent(albumsOutputFolder + '/' + this.basename + '.html')
     this.depth = parent.depth + 1
   }
   // path to the optional ZIP file

--- a/src/model/album.js
+++ b/src/model/album.js
@@ -59,14 +59,7 @@ Album.prototype.finalize = function (options, parent) {
       this.basename = parent.basename + '-' + this.basename
     }
     this.path = path.join(albumsOutputFolder, this.basename + '.html')
-    // Encode characters like ?, #, and space, however, undo the encoding for slashes.
-    // This is needed to support albums and files with these URI-unfriendly characters.
-    // See https://github.com/thumbsup/thumbsup/issues/234
-    this.url = encodeURIComponent(albumsOutputFolder + '/' + this.basename + '.html').replace(/%2F/g, '/')
-    // Shorten the url if it starts with './'
-    if (this.url.startsWith('./')) {
-      this.url = this.url.slice(2)
-    }
+    this.url = this.getUrl(albumsOutputFolder, this.basename + '.html');
     this.depth = parent.depth + 1
   }
   // path to the optional ZIP file
@@ -115,6 +108,18 @@ Album.prototype.calculateSummary = function () {
     itemCount(this.stats.videos, 'video')
   ]
   this.summary = _.compact(items).join(', ')
+}
+
+Album.prototype.getUrl = function (albumsOutputFolder, documentPath) {
+  // Encode characters like ?, # and space, however, undo the encoding for slashes.
+  // This is needed to support albums and files with these URI-unfriendly characters.
+  // See https://github.com/thumbsup/thumbsup/issues/234
+  let url = encodeURIComponent(albumsOutputFolder + '/' + documentPath).replace(/%2F/g, '/')
+  // Shorten the url if it starts with './'
+  if (url.startsWith('./')) {
+    url = url.slice(2)
+  }
+  return url;
 }
 
 Album.prototype.sort = function (options) {

--- a/src/model/album.js
+++ b/src/model/album.js
@@ -59,7 +59,14 @@ Album.prototype.finalize = function (options, parent) {
       this.basename = parent.basename + '-' + this.basename
     }
     this.path = path.join(albumsOutputFolder, this.basename + '.html')
-    this.url = encodeURIComponent(albumsOutputFolder + '/' + this.basename + '.html')
+    // Encode characters like ?, #, and space, however, undo the encoding for slashes.
+    // This is needed to support albums and files with these URI-unfriendly characters.
+    // See https://github.com/thumbsup/thumbsup/issues/234
+    this.url = encodeURIComponent(albumsOutputFolder + '/' + this.basename + '.html').replace(/%2F/g, '/')
+    // Shorten the url if it starts with './'
+    if (this.url.startsWith('./')) {
+      this.url = this.url.slice(2)
+    }
     this.depth = parent.depth + 1
   }
   // path to the optional ZIP file

--- a/src/model/album.js
+++ b/src/model/album.js
@@ -60,7 +60,7 @@ Album.prototype.finalize = function (options, parent) {
       this.basename = parent.basename + '-' + this.basename
     }
     this.path = path.join(albumsOutputFolder, this.basename + '.html')
-    this.url = url.resolve(albumsOutputFolder + '/', this.basename + '.html')
+    this.url = url.resolve(albumsOutputFolder + '/', encodeURIComponent(this.basename) + '.html')
     this.depth = parent.depth + 1
   }
   // path to the optional ZIP file

--- a/src/model/file.js
+++ b/src/model/file.js
@@ -41,7 +41,10 @@ function mediaType (dbEntry) {
 }
 
 function pathToUrl (filepath) {
-  return encodeURIComponent(filepath.replace('\\', '/'))
+  // Encode characters like ?, #, and space, however, undo the encoding for slashes.
+  // This is needed to support albums and files with these URI-unfriendly characters.
+  // See https://github.com/thumbsup/thumbsup/issues/234
+  return encodeURIComponent(filepath.replace('\\', '/')).replace(/%2F/g, '/')
 }
 
 module.exports = File

--- a/src/model/file.js
+++ b/src/model/file.js
@@ -41,7 +41,7 @@ function mediaType (dbEntry) {
 }
 
 function pathToUrl (filepath) {
-  return encodeURI(filepath.replace('\\', '/'))
+  return encodeURIComponent(filepath.replace('\\', '/'))
 }
 
 module.exports = File

--- a/test/model/album.spec.js
+++ b/test/model/album.spec.js
@@ -90,6 +90,24 @@ describe('Album', function () {
       should(root.albums[0].url).eql('2010.html')
     })
 
+    it('encodes # characters when calculating the URL for the browser', function () {
+      const root = new Album({
+        title: 'home',
+        albums: [new Album({ title: '#2010#' })]
+      })
+      root.finalize({ index: 'index.html' })
+      should(root.albums[0].url).eql('%232010%23.html')
+    })
+
+    it('encodes ? characters when calculating the URL for the browser', function () {
+      const root = new Album({
+        title: 'home',
+        albums: [new Album({ title: '?2010?' })]
+      })
+      root.finalize({ index: 'index.html' })
+      should(root.albums[0].url).eql('%3F2010%3F.html')
+    })
+
     it('calculates the output path with a target folder (slashes match the OS)', function () {
       const root = new Album({
         title: 'home',


### PR DESCRIPTION
This is supposed to fix #234.

- What's the current behaviour?
  - Albums containing these characters can't be viewed because the browser reads these as special characters.
- What does the PR change?
  - encodeURIComponent escapes these characters while encodeURI does not. They are valid in URIs, but need to be escaped if the string is a subset (called component) of a URI.  
- Does it introduce a breaking change for existing users?
  - nope, just pure happiness.

This removes the deprecated function `url.resolve`. I guess that was supposed to encode the url.
https://nodejs.org/api/url.html#url_url_resolve_from_to
