### PR TITLE
Support albums and files with the \ character

### DIFF
--- a/src/model/album.js
+++ b/src/model/album.js
@@ -14,7 +14,7 @@ var index = 0
 
 // number of images to show in the album preview grid
 const PREVIEW_COUNT = 10
-const SLUGIFY_OPTIONS = { replacement: '-', remove: /[*+~.()'"!:@]/g }
+const SLUGIFY_OPTIONS = { replacement: '-', remove: /[*+~.()'"!:@\\\/]/g }
 
 const SORT_ALBUMS_BY = {
   'title': function (album) { return album.title },

--- a/src/model/file.js
+++ b/src/model/file.js
@@ -41,7 +41,7 @@ function mediaType (dbEntry) {
 }
 
 function pathToUrl (filepath) {
-  return encodeURI(filepath.replace('\\', '/'))
+  return encodeURI(filepath.replace(RegExp(path.sep, 'g'), '/'))
 }
 
 module.exports = File


### PR DESCRIPTION
This is supposed to fix #240.

- What's the current behaviour?
  - Windows: The URLs of nested albums break. (I guess)
  - Linux: Folders and files with a backslash can't be viewed.
- What does the PR change?
  - Fix for Windows: Use RegExp with the **g**lobal flag. This matches not only the first backslash.
  - Fix for Linux:
    - Use [`path.sep`](https://nodejs.org/api/path.html#path_path_sep) to determine the folder separator string of the OS.
    - Sluggify backslash (and slash, just to be sure) in basenames. The backslash character is handled as a slash by browsers and `encodeURIComponent` doesn't convert it (may even throw).
- Does it introduce a breaking change for existing users?
  - It shouldn't. This aims to fix broken URLs.
- Why is this not part of #235?
  - Because I don't have a Windows machine to test this and don't want to increase the scope of that other issue/PR.