### PR TITLE
metadata: add a "title" property derived from EXIF:DocumentName

### DIFF
--- a/src/model/metadata.js
+++ b/src/model/metadata.js
@@ -25,6 +25,7 @@ class Metadata {
   constructor (exiftool, picasa, opts) {
     // standardise metadata
     this.date = getDate(exiftool)
+    this.title = title(exiftool)
     this.caption = caption(exiftool, picasa)
     this.keywords = keywords(exiftool, picasa)
     this.people = people(exiftool)
@@ -76,6 +77,10 @@ function getFilenameDate (exif) {
     if (parsed.isValid()) return parsed
   }
   return null
+}
+
+function title (exif) {
+  return tagValue(exif, 'EXIF', 'DocumentName')
 }
 
 function caption (exif, picasa) {

--- a/test/model/metadata.spec.js
+++ b/test/model/metadata.spec.js
@@ -131,6 +131,21 @@ describe('Metadata', function () {
     })
   })
 
+  describe('title', function () {
+    it('is read from EXIF', function () {
+      const exiftool = fixtures.exiftool()
+      exiftool.EXIF.DocumentName = 'some document name'
+      const meta = new Metadata(exiftool)
+      should(meta.title).eql('some document name')
+    })
+
+    it('can be missing', function () {
+      const exiftool = fixtures.exiftool()
+      const meta = new Metadata(exiftool)
+      should(meta.title).undefined()
+    })
+  })
+
   describe('caption', function () {
     it('is read from all standard EXIF/IPTC/XMP tags', function () {
       const tags = [


### PR DESCRIPTION
This is generally unset in EXIF, and can be used in templates to display a descriptive image name other than the filename.
