### PR TITLE
Use picasa for album name

### DIFF
--- a/src/input/picasa.js
+++ b/src/input/picasa.js
@@ -13,11 +13,8 @@ class Picasa {
     this.folders = {}
   }
   album (dir) {
-    if (!this.folders[dir]) {
-      this.folders[dir] = loadPicasa(dir)
-    }
+    const entry = loadPicasa(dir)
     // album metadata is stored in a section called [Picasa]
-    const entry = this.folders[dir]
     return entry.Picasa || null
   }
   file (filepath) {

--- a/src/steps/step-index.js
+++ b/src/steps/step-index.js
@@ -51,7 +51,7 @@ exports.run = function (opts, callback) {
     // finished, we can create the albums
     emitter.on('done', stats => {
       const mapper = new AlbumMapper(opts.albumsFrom, opts)
-      const album = hierarchy.createAlbums(files, mapper, opts)
+      const album = hierarchy.createAlbums(files, mapper, opts, picasaReader)
       callback(null, files, album)
       observer.complete()
     })

--- a/test/input/picasa.spec.js
+++ b/test/input/picasa.spec.js
@@ -65,7 +65,7 @@ describe('Picasa', function () {
       'holidays/picasa.ini': PICASA_INI
     })
     const picasa = new Picasa()
-    const meta = picasa.album('holidays/IMG_0002.jpg')
+    const meta = picasa.file('holidays/IMG_0002.jpg')
     should(meta).eql(null)
   })
 })


### PR DESCRIPTION
- What's the current behaviour?

Setting a title for an album via `picasa.ini` is ignored. Given an input structure of:
```
input
└── jordan
    ├── photo.jpg
    └── picasa.ini
```
A `picasa.ini` of:
```
[Picasa]
name=Israel & Jordan Trip

[photo.jpg]
...
```

You still get the album named `jordan` (which shows up in all themes).

- What does the PR change?

Uses the `picasa.ini` defined `Picasa/name` field to name the album instead of just the directory.

- Does it introduce a breaking change for existing users?

If someone had defined the `name` field in their `picasa.ini`, this would start picking it up.