### PR TITLE
Add a mention that imagemagick is needed for HEIC images

### DIFF
--- a/src/cli/dependencies.js
+++ b/src/cli/dependencies.js
@@ -19,6 +19,13 @@ const BINARIES = [
     msg: ''
   },
   {
+    // optional to process HEIC files
+    mandatory: false,
+    cmd: 'magick',
+    url: 'https://imagemagick.org',
+    msg: 'You will not be able to process HEIC images.'
+  },
+  {
     // optional to process videos
     mandatory: false,
     cmd: 'ffmpeg',


### PR DESCRIPTION
I came across the issue described in #278 and realized `imagemagick` isn't mentioned the same way other optional dependencies are (`ffmpeg`…)