### PR TITLE
Allow override of previews; fixes #237

### DIFF
--- a/src/cli/options.js
+++ b/src/cli/options.js
@@ -274,6 +274,11 @@ const OPTIONS = {
     choices: ['first', 'spread', 'random'],
     'default': 'first'
   },
+  'album-covers': {
+    group: 'Album options:',
+    description: 'Optional overrides for album previews',
+    type: 'string'
+  },
 
   // ------------------------------------
   // Website options


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!
Please describe what the change is below, and don't forget to check out the CONTRIBUTING guidelines.

-->

This is an attempt to address #237; the desire to override album previews. The idea is that you define a file with a JSON object containing pairs of basenames (albums or tags) and the relative path to a potential image. Example:

``` json
{
	"Albums-2019-Central-Europe-Lauterbrunnen":"2019 Central Europe/Lauterbrunnen/The Alps 2.jpg",
	"Tags-Capoolong-Creek-Trail": "2020 Social distance/Day 0/Rocky water.jpg"
}
```

I'm sure there's a more efficient way to accomplish this.