### PR TITLE
Add support for userComment

### DIFF
--- a/src/model/metadata.js
+++ b/src/model/metadata.js
@@ -86,7 +86,8 @@ function caption (exif, picasa) {
     tagValue(exif, 'XMP', 'Description') ||
     tagValue(exif, 'XMP', 'Title') ||
     tagValue(exif, 'XMP', 'Label') ||
-    tagValue(exif, 'QuickTime', 'Title')
+    tagValue(exif, 'QuickTime', 'Title') ||
+    tagValue(exif, 'EXIF', 'UserComment')
 }
 
 function keywords (exif, picasa) {


### PR DESCRIPTION
Currently thumbsup does not pull the UserComment field from the file. This PR makes it show up as a last-option for the caption field. That's it.

This would probably be better in it's own field, but it works for me 🤷‍♀️. Not sure if anyone else wants this...