### PR TITLE
Use value of home album name for the home album's zip file

### DIFF
--- a/src/model/album.js
+++ b/src/model/album.js
@@ -66,7 +66,11 @@ Album.prototype.finalize = function (options, parent) {
   }
   // path to the optional ZIP file
   if (options.albumZipFiles && this.files.length > 0) {
-    this.zip = this.path.replace(/\.[^\\/.]+$/, '.zip')
+    if ((parent == null)) {
+      this.zip = options.homeAlbumName.concat('.zip')
+    } else {
+      this.zip = this.path.replace(/\.[^\\/.]+$/, '.zip')
+    }
   }
   // then finalize all nested albums (which uses the parent basename)
   for (let i = 0; i < this.albums.length; ++i) {


### PR DESCRIPTION
- What's the current behaviour?

When creating a gallery with photos in the home (root) album while zip file downloads enabled, the zip file for the home album is titled "index.zip". This is inconsistent with the behavior of sub-galleries, which generate zip files reflecting each album's respective name.

- What does the PR change?

The name of the home album's zip file will now be the value of the --home-albume-name option provided via the CLI or config file, defaulting to "Home.zip" if none is provided.

- Does it introduce a breaking change for existing users?

I do not anticipate this breaking anyone's workflow.
If an existing gallery with an index.zip is updated, a new zip will be created following the new naming convention, and links will be updated accordingly.