### PR TITLE
Theme helpers: relative urls

### DIFF
--- a/src/website/theme-base/helpers/relative.js
+++ b/src/website/theme-base/helpers/relative.js
@@ -6,7 +6,8 @@ module.exports = (target, options) => {
     return target
   }
   const albumPath = options.data.root.album.path
-  const relative = path.relative(path.dirname(albumPath), target)
+  const backToGalleryRoot = path.relative(path.dirname(albumPath), '.')
+  const relative = path.join(backToGalleryRoot, target)
   const url = relative.replace(/\\/g, '/')
   // Escape single/double quotes
   return url.replace(/'/g, '%27').replace(/"/g, '%22')

--- a/test/themes/helpers/relative.spec.js
+++ b/test/themes/helpers/relative.spec.js
@@ -48,6 +48,26 @@ describe('Handlebars helpers: relative', () => {
       should(res).eql('<img src="../media/thumbs/img.jpg" />')
     })
 
+    it('can use a relative link from the root album', () => {
+      const template = handlebars.compile('<link rel="stylesheet" href="{{relative \'../../photos/img.jpg\'}}" />')
+      const res = template({
+        album: {
+          path: 'index.html'
+        }
+      })
+      should(res).eql('<link rel="stylesheet" href="../../photos/img.jpg" />')
+    })
+
+    it('can use relative link from a nested album', () => {
+      const template = handlebars.compile('<link rel="stylesheet" href="{{relative \'../../photos/img.jpg\'}}" />')
+      const res = template({
+        album: {
+          path: 'albums/holidays.html'
+        }
+      })
+      should(res).eql('<link rel="stylesheet" href="../../../photos/img.jpg" />')
+    })
+
     it('does not do anything if the path is an absolute URL', () => {
       // This can happen when using --link-prefix
       const url = 'http://example.com/photo.jpg'

--- a/test/themes/helpers/relative.spec.js
+++ b/test/themes/helpers/relative.spec.js
@@ -1,59 +1,85 @@
-const date = require('../../../src/website/theme-base/helpers/relative')
+const relative = require('../../../src/website/theme-base/helpers/relative')
 const handlebars = require('handlebars')
 const should = require('should/as-function')
 
 describe('Handlebars helpers: relative', () => {
-  handlebars.registerHelper('relative', date)
+  handlebars.registerHelper('relative', relative)
 
-  it('returns a path in the same folder', () => {
-    const template = handlebars.compile('<link rel="stylesheet" href="{{relative \'public/theme.css\'}}" />')
-    const res = template({
-      album: {
-        path: 'index.html'
-      }
+  describe('theme assets', () => {
+    it('returns a path in the same folder', () => {
+      const template = handlebars.compile('<link rel="stylesheet" href="{{relative \'public/theme.css\'}}" />')
+      const res = template({
+        album: {
+          path: 'index.html'
+        }
+      })
+      should(res).eql('<link rel="stylesheet" href="public/theme.css" />')
     })
-    should(res).eql('<link rel="stylesheet" href="public/theme.css" />')
+
+    it('returns a relative path for albums in nested folders', () => {
+      const template = handlebars.compile('<link rel="stylesheet" href="{{relative \'public/theme.css\'}}" />')
+      const res = template({
+        album: {
+          path: 'albums/holidays.html'
+        }
+      })
+      should(res).eql('<link rel="stylesheet" href="../public/theme.css" />')
+    })
   })
 
-  it('returns a relative path for albums in nested folders', () => {
-    const template = handlebars.compile('<link rel="stylesheet" href="{{relative \'public/theme.css\'}}" />')
-    const res = template({
-      album: {
-        path: 'albums/holidays.html'
-      }
+  describe('images and videos', () => {
+    it('returns a path from the root album', () => {
+      const template = handlebars.compile('<img src="{{relative \'media/thumbs/img.jpg\'}}" />')
+      const res = template({
+        album: {
+          path: 'index.html'
+        }
+      })
+      should(res).eql('<img src="media/thumbs/img.jpg" />')
     })
-    should(res).eql('<link rel="stylesheet" href="../public/theme.css" />')
+
+    it('returns a path from a nested album', () => {
+      const template = handlebars.compile('<img src="{{relative \'media/thumbs/img.jpg\'}}" />')
+      const res = template({
+        album: {
+          path: 'albums/holidays.html'
+        }
+      })
+      should(res).eql('<img src="../media/thumbs/img.jpg" />')
+    })
+
+    it('does not do anything if the path is an absolute URL', () => {
+      // This can happen when using --link-prefix
+      const url = 'http://example.com/photo.jpg'
+      const template = handlebars.compile(`<img src="{{relative '${url}'}}" />`)
+      const res = template({})
+      should(res).eql(`<img src="${url}" />`)
+    })
   })
 
-  it('does not do anything if the path is an absolute URL', () => {
-    // This can happen when using --link-prefix
-    const url = 'http://example.com/photo.jpg'
-    const template = handlebars.compile(`<img src="{{relative '${url}'}}" />`)
-    const res = template({})
-    should(res).eql(`<img src="${url}" />`)
-  })
-
-  // TODO: this should not be needed anymore because all URLs are already escaped
-  it('escapes single quotes so they can be used in CSS background-image', () => {
-    const template = handlebars.compile("background-image('{{relative url}}')")
-    const res = template({
-      url: "l'histoire.jpg",
-      album: {
-        path: 'index.html'
-      }
+  describe('escaping', () => {
+    // TODO: this should not be needed anymore because all URLs are already escaped
+    it('escapes single quotes so they can be used in CSS background-image', () => {
+      const template = handlebars.compile("background-image('{{relative url}}')")
+      const res = template({
+        url: "l'histoire.jpg",
+        album: {
+          path: 'index.html'
+        }
+      })
+      should(res).eql("background-image('l%27histoire.jpg')")
     })
-    should(res).eql("background-image('l%27histoire.jpg')")
-  })
 
-  // TODO: this should not be needed anymore because all URLs are already escaped
-  it('escapes double quotes so they can be used in <img> tags', () => {
-    const template = handlebars.compile('<img src="{{relative url}}" />')
-    const res = template({
-      url: 'l"histoire.jpg',
-      album: {
-        path: 'index.html'
-      }
+    // TODO: this should not be needed anymore because all URLs are already escaped
+    it('escapes double quotes so they can be used in <img> tags', () => {
+      const template = handlebars.compile('<img src="{{relative url}}" />')
+      const res = template({
+        url: 'l"histoire.jpg',
+        album: {
+          path: 'index.html'
+        }
+      })
+      should(res).eql('<img src="l%22histoire.jpg" />')
     })
-    should(res).eql('<img src="l%22histoire.jpg" />')
   })
 })


### PR DESCRIPTION
This PR adds tests for the `relative` theme helper.

The new tests seem to pass on some systems, but not inside the Docker image.

```bash
expected
<link rel="stylesheet" href="../../photos/img.jpg" />

actual
<link rel="stylesheet" href="../photos/img.jpg" />
```

This could explain #351.