### PR TITLE
Update documentation for deprecated features

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ Misc options:
   --dry-run        Update the index, but don't create the media files / website  [boolean] [default: false]
 
 Deprecated:
-  --original-photos       Copy and allow download of full-size photos  [boolean]
-  --original-videos       Copy and allow download of full-size videos  [boolean]
+  --original-photos       Copy and allow download of full-size photos (use --photo-download=copy)  [boolean]
+  --original-videos       Copy and allow download of full-size videos (use --video-download=copy)  [boolean]
   --albums-date-format    How albums are named in <date> mode [moment.js pattern]
   --css                   Path to a custom provided CSS/LESS file for styling  [string]
   --download-photos       Target of the photo download links  [choices: "large", "copy", "symlink", "link"]

--- a/src/cli/options.js
+++ b/src/cli/options.js
@@ -406,12 +406,12 @@ const OPTIONS = {
 
   'original-photos': {
     group: 'Deprecated:',
-    description: 'Copy and allow download of full-size photos',
+    description: 'Copy and allow download of full-size photos (use --photo-download=copy)',
     type: 'boolean'
   },
   'original-videos': {
     group: 'Deprecated:',
-    description: 'Copy and allow download of full-size videos',
+    description: 'Copy and allow download of full-size videos (use --video-download=copy)',
     type: 'boolean'
   },
   'albums-date-format': {


### PR DESCRIPTION
Guide the user to the commands that have replaced --original-photos and --original-videos.