### PR TITLE
feat: nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ test-snapshot/output-expected/metadata.json
 .DS_Store
 thumbsup.db
 tmp*
+result
+.direnv/
+/.pre-commit-config.yaml

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,114 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 0,
+        "narHash": "sha256-C8e9S7RzshSdHB7L+v9I51af1gDM5unhJ2xO1ywxNH8=",
+        "path": "/nix/store/4p0avw1s3vf27hspgqsrqs37gxk4i83i-source",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1718811006,
+        "narHash": "sha256-0Y8IrGhRmBmT7HHXlxxepg2t8j1X90++qRN3lukGaIk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "03d771e513ce90147b65fe922d87d3a0356fc125",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1719082008,
+        "narHash": "sha256-jHJSUH619zBQ6WdC21fFAlDxHErKVDJ5fpN0Hgx4sjs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9693852a2070b398ee123a329e68f0dab5526681",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs_2",
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1719259945,
+        "narHash": "sha256-F1h+XIsGKT9TkGO3omxDLEb/9jOOsI6NnzsXFsZhry4=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "0ff4381bbb8f7a52ca4a851660fc7a437a4c6e07",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,86 @@
+{
+  description = "A nix-flake-based packaging of thumbsup";
+
+  inputs = {
+    pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    pre-commit-hooks,
+  }: let
+    supportedSystems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
+    forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+  in {
+    checks = forAllSystems (system: {
+      pre-commit-check = pre-commit-hooks.lib.${system}.run {
+        src = ./.;
+        hooks = {
+          alejandra.enable = true;
+          alejandra.settings = {
+            check = true;
+          };
+          deadnix.enable = true;
+          deadnix.settings = {
+            noLambdaArg = true;
+            noLambdaPatternNames = true;
+          };
+          statix.enable = true;
+        };
+      };
+    });
+
+    packages = forAllSystems (system: {
+      default = nixpkgs.legacyPackages.${system}.buildNpmPackage {
+        pname = "thumbsup";
+        version = "2.18.0";
+        src = ./.;
+
+        npmDepsHash = "sha256-JcQvKwavHqSN5IK8Aal7KEew40afDmoBhEXSiHOhbz4=";
+        npmPackFlags = ["--ignore-scripts"];
+        dontNpmBuild = true;
+        NODE_OPTIONS = "--openssl-legacy-provider";
+
+        meta = with nixpkgs.legacyPackages.${system}.lib; {
+          homepage = "https://github.com/thumbsup/thumbsup";
+          description = "Thumbsup is a static gallery generator.";
+          mainProgram = "thumbsup";
+          longDescription = ''
+            Thumbsup is a static gallery generator. Point it at a folder full
+            of photos and videos, and it will build an HTML website to view
+            them. It takes care of resizing photos, creating thumbnails,
+            re-encoding videos to a web-friendly format, and more.
+          '';
+          maintainers = [maintainers.x123];
+          license = licenses.mit;
+        };
+      };
+    });
+
+    devShells = forAllSystems (system: {
+      default = nixpkgs.legacyPackages.${system}.mkShell {
+        inherit (self.checks.${system}.pre-commit-check) shellHook;
+        buildInputs = self.checks.${system}.pre-commit-check.enabledPackages;
+        packages = [
+          self.packages.${system}.default
+
+          # Package ‘dcraw-9.28.0’ is marked as insecure due to CVEs:
+          # CVE-2018-19655
+          # CVE-2018-19565
+          # CVE-2018-19566
+          # CVE-2018-19567
+          # CVE-2018-19568
+          # if you wish to enable dcraw the following line can be uncommented
+          # nixpkgs.legacyPackages.${system}.dcraw
+
+          nixpkgs.legacyPackages.${system}.exiftool
+          nixpkgs.legacyPackages.${system}.ffmpeg
+          nixpkgs.legacyPackages.${system}.gifsicle
+          nixpkgs.legacyPackages.${system}.graphicsmagick
+          nixpkgs.legacyPackages.${system}.imagemagick
+        ];
+      };
+    });
+  };
+}


### PR DESCRIPTION
- What does the PR change?
This PR introduces a basic nix flake that allows for a reproducible and declarative development shell and package derivation that allows anyone using nix to easily include thumbsup in their system config, or develop on it.

- Does it introduce a breaking change for existing users?
None, it will only be relevant for nix / NixOS users.

If nix is available on an existing platform, a user can easily jump into a dev shell with `nix develop` locally or `nix develop github:thumbsup/thumbsup`