### PR TITLE
Docker HW video acceleration fix and Docker build script parameterization

### DIFF
--- a/.github/workflows/publish-docker-base.yml
+++ b/.github/workflows/publish-docker-base.yml
@@ -23,7 +23,9 @@ jobs:
         with:
           context: docker
           file: ./docker/Dockerfile.runtime
-          build-args: NODE_VERSION=${{ matrix.nodejs }}
+          build-args: |
+            NODE_VERSION=${{ matrix.nodejs }}
+            REPO_OWNER=${{ github.repository_owner }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: ghcr.io/${{ github.repository_owner }}/thumbsup/runtime:node-${{ matrix.nodejs }}
           push: true
@@ -32,7 +34,9 @@ jobs:
         with:
           context: docker
           file: ./docker/Dockerfile.build
-          build-args: NODE_VERSION=${{ matrix.nodejs }}
+          build-args: |
+            NODE_VERSION=${{ matrix.nodejs }}
+            REPO_OWNER=${{ github.repository_owner }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: ghcr.io/${{ github.repository_owner }}/thumbsup/build:node-${{ matrix.nodejs }}
           push: true

--- a/.github/workflows/publish-docker-base.yml
+++ b/.github/workflows/publish-docker-base.yml
@@ -23,7 +23,9 @@ jobs:
         with:
           context: docker
           file: ./docker/Dockerfile.runtime
-          build-args: NODE_VERSION=${{ matrix.nodejs }}
+          build-args: |
+            REPO_OWNER=${{ github.repository_owner }}
+            NODE_VERSION=${{ matrix.nodejs }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: ghcr.io/${{ github.repository_owner }}/thumbsup/runtime:node-${{ matrix.nodejs }}
           push: true

--- a/.github/workflows/publish-docker-base.yml
+++ b/.github/workflows/publish-docker-base.yml
@@ -24,8 +24,8 @@ jobs:
           context: docker
           file: ./docker/Dockerfile.runtime
           build-args: |
-            REPO_OWNER=${{ github.repository_owner }}
             NODE_VERSION=${{ matrix.nodejs }}
+            REPO_OWNER=${{ github.repository_owner }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: ghcr.io/${{ github.repository_owner }}/thumbsup/runtime:node-${{ matrix.nodejs }}
           push: true

--- a/.github/workflows/publish-docker-base.yml
+++ b/.github/workflows/publish-docker-base.yml
@@ -25,7 +25,7 @@ jobs:
           file: ./docker/Dockerfile.runtime
           build-args: NODE_VERSION=${{ matrix.nodejs }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
-          tags: ghcr.io/thumbsup/runtime:node-${{ matrix.nodejs }}
+          tags: ghcr.io/${{ github.repository_owner }}/thumbsup/runtime:node-${{ matrix.nodejs }}
           push: true
       - name: Publish thumbsup/build
         uses: docker/build-push-action@v2
@@ -34,5 +34,5 @@ jobs:
           file: ./docker/Dockerfile.build
           build-args: NODE_VERSION=${{ matrix.nodejs }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
-          tags: ghcr.io/thumbsup/build:node-${{ matrix.nodejs }}
+          tags: ghcr.io/${{ github.repository_owner }}/thumbsup/build:node-${{ matrix.nodejs }}
           push: true

--- a/.github/workflows/publish-docker-base.yml
+++ b/.github/workflows/publish-docker-base.yml
@@ -23,9 +23,7 @@ jobs:
         with:
           context: docker
           file: ./docker/Dockerfile.runtime
-          build-args: |
-            NODE_VERSION=${{ matrix.nodejs }}
-            REPO_OWNER=${{ github.repository_owner }}
+          build-args: NODE_VERSION=${{ matrix.nodejs }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: ghcr.io/${{ github.repository_owner }}/thumbsup/runtime:node-${{ matrix.nodejs }}
           push: true

--- a/.github/workflows/publish-docker-base.yml
+++ b/.github/workflows/publish-docker-base.yml
@@ -25,7 +25,7 @@ jobs:
           file: ./docker/Dockerfile.runtime
           build-args: NODE_VERSION=${{ matrix.nodejs }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
-          tags: ghcr.io/thumbsup2/runtime:node-${{ matrix.nodejs }}
+          tags: ghcr.io/thumbsup/runtime:node-${{ matrix.nodejs }}
           push: true
       - name: Publish thumbsup/build
         uses: docker/build-push-action@v2
@@ -34,5 +34,5 @@ jobs:
           file: ./docker/Dockerfile.build
           build-args: NODE_VERSION=${{ matrix.nodejs }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
-          tags: ghcr.io/thumbsup2/build:node-${{ matrix.nodejs }}
+          tags: ghcr.io/thumbsup/build:node-${{ matrix.nodejs }}
           push: true

--- a/.github/workflows/publish-docker-base.yml
+++ b/.github/workflows/publish-docker-base.yml
@@ -25,7 +25,7 @@ jobs:
           file: ./docker/Dockerfile.runtime
           build-args: NODE_VERSION=${{ matrix.nodejs }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
-          tags: ghcr.io/thumbsup/runtime:node-${{ matrix.nodejs }}
+          tags: ghcr.io/thumbsup2/runtime:node-${{ matrix.nodejs }}
           push: true
       - name: Publish thumbsup/build
         uses: docker/build-push-action@v2
@@ -34,5 +34,5 @@ jobs:
           file: ./docker/Dockerfile.build
           build-args: NODE_VERSION=${{ matrix.nodejs }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
-          tags: ghcr.io/thumbsup/build:node-${{ matrix.nodejs }}
+          tags: ghcr.io/thumbsup2/build:node-${{ matrix.nodejs }}
           push: true

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -30,6 +30,6 @@ jobs:
           build-args: PACKAGE_VERSION=${{ steps.version.outputs.version }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: |
-            ghcr.io/thumbsup/thumbsup2:${{ steps.version.outputs.version }}
-            ghcr.io/thumbsup/thumbsup2:latest
+            ghcr.io/${{ github.repository_owner }}/thumbsup:${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/thumbsup:latest
           push: true

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -30,6 +30,6 @@ jobs:
           build-args: PACKAGE_VERSION=${{ steps.version.outputs.version }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: |
-            ghcr.io/thumbsup/thumbsup:${{ steps.version.outputs.version }}
-            ghcr.io/thumbsup/thumbsup:latest
+            ghcr.io/thumbsup/thumbsup2:${{ steps.version.outputs.version }}
+            ghcr.io/thumbsup/thumbsup2:latest
           push: true

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -36,5 +36,5 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/thumbsup:${{ steps.version.outputs.version }}
             ghcr.io/${{ github.repository_owner }}/thumbsup:latest
           push: true
-          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description="Docker image for thumbsup image and video gallery"
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=Docker image for thumbsup image and video gallery
 

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -27,7 +27,10 @@ jobs:
         with:
           context: docker
           file: ./docker/Dockerfile.release
-          build-args: PACKAGE_VERSION=${{ steps.version.outputs.version }}
+          build-args: | 
+            PACKAGE_VERSION=${{ steps.version.outputs.version }}
+            NODE_VERSION=18
+            REPO_OWNER=${{ github.repository_owner }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: |
             ghcr.io/${{ github.repository_owner }}/thumbsup:${{ steps.version.outputs.version }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -29,7 +29,7 @@ jobs:
           file: ./docker/Dockerfile.release
           build-args: | 
             PACKAGE_VERSION=${{ steps.version.outputs.version }}
-            NODE_VERSION=18
+            NODE_VERSION=20
             REPO_OWNER=${{ github.repository_owner }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: |

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -36,3 +36,5 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/thumbsup:${{ steps.version.outputs.version }}
             ghcr.io/${{ github.repository_owner }}/thumbsup:latest
           push: true
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description="Docker image for thumbsup image and video gallery"
+

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -29,7 +29,7 @@ jobs:
           file: ./docker/Dockerfile.release
           build-args: | 
             PACKAGE_VERSION=${{ steps.version.outputs.version }}
-            NODE_VERSION=20
+            NODE_VERSION=18
             REPO_OWNER=${{ github.repository_owner }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: |

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -17,3 +17,6 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile.test
+          build-args: |
+            NODE_VERSION=18
+            REPO_OWNER=${{ github.repository_owner }}

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -18,5 +18,5 @@ jobs:
           context: .
           file: ./docker/Dockerfile.test
           build-args: |
-            NODE_VERSION=18
+            NODE_VERSION=20
             REPO_OWNER=${{ github.repository_owner }}

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -13,9 +13,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
-      - uses: docker/login-action@v1 
-        with:
-          registry: ghcr.io
       - uses: docker/build-push-action@v2
         with:
           context: .

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -16,8 +16,6 @@ jobs:
       - uses: docker/login-action@v1 
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
       - uses: docker/build-push-action@v2
         with:
           context: .

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -18,5 +18,5 @@ jobs:
           context: .
           file: ./docker/Dockerfile.test
           build-args: |
-            NODE_VERSION=20
+            NODE_VERSION=18
             REPO_OWNER=${{ github.repository_owner }}

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -13,6 +13,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
+      - uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
       - uses: docker/build-push-action@v2
         with:
           context: .

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
       - run: choco install exiftool graphicsmagick
       # GraphicsMagick must be manually added to the path 
       - run: |

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '18'
       - run: choco install exiftool graphicsmagick
       # GraphicsMagick must be manually added to the path 
       - run: |

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -5,7 +5,7 @@
 ARG NODE_VERSION
 
 # Node.js + runtime dependencies
-FROM ghcr.io/thumbsup/runtime:node-${NODE_VERSION}
+FROM ghcr.io/thumbsup2/runtime:node-${NODE_VERSION}
 
 # Standard build dependencies for npm install
 RUN apk add --no-cache git make g++ python3 bash

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -5,7 +5,7 @@
 ARG NODE_VERSION
 
 # Node.js + runtime dependencies
-FROM ghcr.io/thumbsup2/runtime:node-${NODE_VERSION}
+FROM ghcr.io/thumbsup/runtime:node-${NODE_VERSION}
 
 # Standard build dependencies for npm install
 RUN apk add --no-cache git make g++ python3 bash

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -2,10 +2,11 @@
 # This Docker image is used to speed up the builds
 # -------------------------------------------------
 
-ARG NODE_VERSION
+ARG NODE_VERSION=[18, 20]
+ARG REPO_OWNER=thumbsup
 
 # Node.js + runtime dependencies
-FROM ghcr.io/thumbsup/runtime:node-${NODE_VERSION}
+FROM ghcr.io/${REPO_OWNER}/thumbsup/runtime:node-${NODE_VERSION}
 
 # Standard build dependencies for npm install
 RUN apk add --no-cache git make g++ python3 bash

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -21,9 +21,6 @@ RUN npm install thumbsup@${PACKAGE_VERSION}
 
 FROM ghcr.io/${REPO_OWNER}/thumbsup/runtime:node-${NODE_VERSION}
 
-ARG REPO_OWNER=thumbsup
-LABEL org.opencontainers.image.source="https://github.com/${REPO_OWNER}/thumbsup"
-
 # Use tini as an init process
 # to ensure all child processes (ffmpeg...) are always terminated properly
 RUN apk add --update tini

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -15,6 +15,8 @@ RUN if [ -z "${PACKAGE_VERSION}" ]; then \
 RUN echo '{"name": "installer", "version": "1.0.0"}' > package.json
 RUN npm install thumbsup@${PACKAGE_VERSION}
 
+RUN echo "1****OWNER=${REPO_OWNER}"
+
 # ------------------------------------------------
 # Runtime image
 # ------------------------------------------------
@@ -32,6 +34,8 @@ ENV HOME /tmp
 # Copy the thumbsup files to the new image
 COPY --from=build /thumbsup /thumbsup
 RUN ln -s /thumbsup/node_modules/.bin/thumbsup /usr/local/bin/thumbsup
+
+RUN echo "2****OWNER=${REPO_OWNER}"
 
 # Default command, should be overridden during <docker run>
 CMD ["thumbsup"]

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -18,7 +18,7 @@ RUN npm install thumbsup@${PACKAGE_VERSION}
 # Runtime image
 # ------------------------------------------------
 
-FROM ghcr.io/thumbsup2/runtime:node-18
+FROM ghcr.io/thumbsup/runtime:node-18
 
 # Use tini as an init process
 # to ensure all child processes (ffmpeg...) are always terminated properly

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -2,7 +2,7 @@
 # Builder image
 # ------------------------------------------------
 
-FROM ghcr.io/thumbsup/build:node-18 as build
+FROM ghcr.io/dravenst/thumbsup/build:node-18 as build
 
 # Install thumbsup locally
 WORKDIR /thumbsup
@@ -18,7 +18,7 @@ RUN npm install thumbsup@${PACKAGE_VERSION}
 # Runtime image
 # ------------------------------------------------
 
-FROM ghcr.io/thumbsup/runtime:node-18
+FROM ghcr.io/dravenst/thumbsup/runtime:node-18
 
 # Use tini as an init process
 # to ensure all child processes (ffmpeg...) are always terminated properly

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -1,8 +1,9 @@
 # ------------------------------------------------
 # Builder image
 # ------------------------------------------------
-
-FROM ghcr.io/dravenst/thumbsup/build:node-18 as build
+ARG THUMBSUP_REPO_NAME = "thumbsup"
+ARG NODE_VERSION = "18"
+FROM ghcr.io/${REPO_OWNER}/thumbsup/build:node-${NODE_VERSION} as build
 
 # Install thumbsup locally
 WORKDIR /thumbsup
@@ -18,7 +19,7 @@ RUN npm install thumbsup@${PACKAGE_VERSION}
 # Runtime image
 # ------------------------------------------------
 
-FROM ghcr.io/dravenst/thumbsup/runtime:node-18
+FROM ghcr.io/${REPO_OWNER}/thumbsup/runtime:node-${NODE_VERSION}
 
 # Use tini as an init process
 # to ensure all child processes (ffmpeg...) are always terminated properly

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -2,7 +2,7 @@
 # Builder image
 # ------------------------------------------------
 ARG REPO_OWNER=thumbsup
-ARG NODE_VERSION=20
+ARG NODE_VERSION=18
 FROM ghcr.io/${REPO_OWNER}/thumbsup/build:node-${NODE_VERSION} AS build
 
 # Install thumbsup locally

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -15,8 +15,6 @@ RUN if [ -z "${PACKAGE_VERSION}" ]; then \
 RUN echo '{"name": "installer", "version": "1.0.0"}' > package.json
 RUN npm install thumbsup@${PACKAGE_VERSION}
 
-RUN echo "1****OWNER=${REPO_OWNER}"
-
 # ------------------------------------------------
 # Runtime image
 # ------------------------------------------------
@@ -34,8 +32,6 @@ ENV HOME /tmp
 # Copy the thumbsup files to the new image
 COPY --from=build /thumbsup /thumbsup
 RUN ln -s /thumbsup/node_modules/.bin/thumbsup /usr/local/bin/thumbsup
-
-RUN echo "2****OWNER=${REPO_OWNER}"
 
 # Default command, should be overridden during <docker run>
 CMD ["thumbsup"]

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -21,6 +21,7 @@ RUN npm install thumbsup@${PACKAGE_VERSION}
 
 FROM ghcr.io/${REPO_OWNER}/thumbsup/runtime:node-${NODE_VERSION}
 
+ARG REPO_OWNER=thumbsup
 LABEL org.opencontainers.image.source="https://github.com/${REPO_OWNER}/thumbsup"
 
 # Use tini as an init process

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -2,7 +2,7 @@
 # Builder image
 # ------------------------------------------------
 
-FROM ghcr.io/thumbsup/build:node-18 as build
+FROM ghcr.io/thumbsup2/build:node-18 as build
 
 # Install thumbsup locally
 WORKDIR /thumbsup
@@ -18,7 +18,7 @@ RUN npm install thumbsup@${PACKAGE_VERSION}
 # Runtime image
 # ------------------------------------------------
 
-FROM ghcr.io/thumbsup/runtime:node-18
+FROM ghcr.io/thumbsup2/runtime:node-18
 
 # Use tini as an init process
 # to ensure all child processes (ffmpeg...) are always terminated properly

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -3,7 +3,7 @@
 # ------------------------------------------------
 ARG REPO_OWNER=thumbsup
 ARG NODE_VERSION=20
-FROM ghcr.io/${REPO_OWNER}/thumbsup/build:node-${NODE_VERSION} as build
+FROM ghcr.io/${REPO_OWNER}/thumbsup/build:node-${NODE_VERSION} AS build
 
 # Install thumbsup locally
 WORKDIR /thumbsup

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -1,8 +1,8 @@
 # ------------------------------------------------
 # Builder image
 # ------------------------------------------------
-ARG THUMBSUP_REPO_NAME = "thumbsup"
-ARG NODE_VERSION = "18"
+ARG REPO_OWNER=thumbsup
+ARG NODE_VERSION=18
 FROM ghcr.io/${REPO_OWNER}/thumbsup/build:node-${NODE_VERSION} as build
 
 # Install thumbsup locally

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -2,7 +2,7 @@
 # Builder image
 # ------------------------------------------------
 
-FROM ghcr.io/thumbsup2/build:node-18 as build
+FROM ghcr.io/thumbsup/build:node-18 as build
 
 # Install thumbsup locally
 WORKDIR /thumbsup

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -2,7 +2,7 @@
 # Builder image
 # ------------------------------------------------
 ARG REPO_OWNER=thumbsup
-ARG NODE_VERSION=18
+ARG NODE_VERSION=20
 FROM ghcr.io/${REPO_OWNER}/thumbsup/build:node-${NODE_VERSION} as build
 
 # Install thumbsup locally

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -21,6 +21,8 @@ RUN npm install thumbsup@${PACKAGE_VERSION}
 
 FROM ghcr.io/${REPO_OWNER}/thumbsup/runtime:node-${NODE_VERSION}
 
+LABEL org.opencontainers.image.source="https://github.com/${REPO_OWNER}/thumbsup"
+
 # Use tini as an init process
 # to ensure all child processes (ffmpeg...) are always terminated properly
 RUN apk add --update tini

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -17,8 +17,8 @@ RUN apk add --update --no-cache libgomp zlib libpng libjpeg-turbo libwebp tiff l
 RUN apk add --update --no-cache ffmpeg imagemagick graphicsmagick exiftool gifsicle zip
 
 # Add intel video acceleration driver if x86/amd64 architecture
-ARG TARGETARCH BUILDARCH
-RUN echo "Target Arch =${TARGETARCH} and Build Arch=${BUILDARCH}"; \
+ARG TARGETARCH
+RUN echo "Target Arch =${TARGETARCH}"; \
     if [[ "${TARGETARCH}" == "amd64" ]]; then \
-    apk add --update --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/latest-stable/community intel-media-driver; \
+    apk add --update --no-cache intel-media-driver; \
     fi;

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -18,7 +18,6 @@ RUN apk add --update --no-cache ffmpeg imagemagick graphicsmagick exiftool gifsi
 
 # Add intel video acceleration driver if x86/amd64 architecture
 ARG TARGETARCH
-RUN echo "Target Arch =${TARGETARCH}"; \
-    if [[ "${TARGETARCH}" == "amd64" ]]; then \
+RUN if [[ "${TARGETARCH}" == "amd64" ]]; then \
     apk add --update --no-cache intel-media-driver; \
     fi;

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -17,6 +17,7 @@ RUN apk add --update --no-cache libgomp zlib libpng libjpeg-turbo libwebp tiff l
 RUN apk add --update --no-cache ffmpeg imagemagick graphicsmagick exiftool gifsicle zip
 
 # Add intel video acceleration driver if x86/amd64 architecture
-RUN if [[ "${TARGETARCH}" == "amd64" ]]; then \
+RUN echo "Target Arch =${TARGETARCH} and Build Arch="${BUILDARCH}"; \
+    if [[ "${TARGETARCH}" == "amd64" ]]; then \
     apk add --update --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/latest-stable/community intel-media-driver; \
     fi;

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -10,7 +10,6 @@ FROM node:${NODE_VERSION}-alpine AS base
 
 # Metadata
 ARG REPO_OWNER=thumbsup
-RUN echo "REPO_OWNER=${REPO_OWNER}"
 LABEL org.opencontainers.image.source=https://github.com/${REPO_OWNER}/thumbsup
 
 # Add libraries

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -5,11 +5,13 @@
 # -------------------------------------------------
 
 ARG NODE_VERSION=[18, 20]
+ARG REPO_OWNER=thumbsup
 
 FROM node:${NODE_VERSION}-alpine AS base
 
 # Metadata
-LABEL "org.opencontainers.image.source"="https://github.com/thumbsup/thumbsup"
+RUN echo "OWNER=${REPO_OWNER}"
+LABEL org.opencontainers.image.source=https://github.com/${REPO_OWNER}/thumbsup
 
 # Add libraries
 RUN apk add --update --no-cache libgomp zlib libpng libjpeg-turbo libwebp tiff lcms2 x265 libde265 libheif

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -17,6 +17,6 @@ RUN apk add --update --no-cache libgomp zlib libpng libjpeg-turbo libwebp tiff l
 RUN apk add --update --no-cache ffmpeg imagemagick graphicsmagick exiftool gifsicle zip
 
 # Add intel video acceleration driver if x86/amd64 architecture
-RUN if [[ "${TARGETARCH}" == "amd64"]]; then \
+RUN if [[ "${TARGETARCH}" == "amd64" ]]; then \
     apk add --update --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/latest-stable/community intel-media-driver; \
     fi;

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -11,7 +11,7 @@ FROM node:${NODE_VERSION}-alpine AS base
 # Metadata
 ARG REPO_OWNER=thumbsup
 RUN echo "REPO_OWNER=${REPO_OWNER}"
-LABEL org.opencontainers.image.source https://github.com/${REPO_OWNER}/thumbsup
+LABEL org.opencontainers.image.source=https://github.com/${REPO_OWNER}/thumbsup
 
 # Add libraries
 RUN apk add --update --no-cache libgomp zlib libpng libjpeg-turbo libwebp tiff lcms2 x265 libde265 libheif

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -9,7 +9,7 @@ ARG REPO_OWNER=thumbsup
 FROM node:${NODE_VERSION}-alpine as base
 
 # Metadata
-LABEL org.opencontainers.image.source https://github.com/${REPO_OWNER}/thumbsup
+LABEL "org.opencontainers.image.source"="https://github.com/${REPO_OWNER}/thumbsup"
 
 # Add libraries
 RUN apk add --update --no-cache libgomp zlib libpng libjpeg-turbo libwebp tiff lcms2 x265 libde265 libheif

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -10,7 +10,6 @@ FROM node:${NODE_VERSION}-alpine AS base
 
 # Metadata
 ARG REPO_OWNER=thumbsup
-RUN echo "OWNER=${REPO_OWNER}"
 LABEL org.opencontainers.image.source=https://github.com/${REPO_OWNER}/thumbsup
 
 # Add libraries

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -16,5 +16,7 @@ RUN apk add --update --no-cache libgomp zlib libpng libjpeg-turbo libwebp tiff l
 # Add external programs
 RUN apk add --update --no-cache ffmpeg imagemagick graphicsmagick exiftool gifsicle zip
 
-# Add video acceleration driver
-RUN apk add --update --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/latest-stable/community intel-media-driver
+# Add intel video acceleration driver if x86/amd64 architecture
+RUN if [[ "${TARGETARCH}" == "amd64"]]; then \
+    apk add --update --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/latest-stable/community intel-media-driver; \
+    fi

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -17,7 +17,7 @@ RUN apk add --update --no-cache libgomp zlib libpng libjpeg-turbo libwebp tiff l
 RUN apk add --update --no-cache ffmpeg imagemagick graphicsmagick exiftool gifsicle zip
 
 # Add intel video acceleration driver if x86/amd64 architecture
-RUN echo "Target Arch =${TARGETARCH} and Build Arch="${BUILDARCH}"; \
+RUN echo "Target Arch =${TARGETARCH} and Build Arch=${BUILDARCH}"; \
     if [[ "${TARGETARCH}" == "amd64" ]]; then \
     apk add --update --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/latest-stable/community intel-media-driver; \
     fi;

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -8,7 +8,7 @@ ARG NODE_VERSION
 FROM node:${NODE_VERSION}-alpine as base
 
 # Metadata
-LABEL org.opencontainers.image.source https://github.com/${{ github.repository_owner }}/thumbsup
+LABEL org.opencontainers.image.source https://github.com/thumbsup/thumbsup
 
 # Add libraries
 RUN apk add --update --no-cache libgomp zlib libpng libjpeg-turbo libwebp tiff lcms2 x265 libde265 libheif

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -8,7 +8,7 @@ ARG NODE_VERSION
 FROM node:${NODE_VERSION}-alpine as base
 
 # Metadata
-LABEL org.opencontainers.image.source https://github.com/thumbsup/thumbsup
+LABEL org.opencontainers.image.source https://github.com/${{ github.repository_owner }}/thumbsup
 
 # Add libraries
 RUN apk add --update --no-cache libgomp zlib libpng libjpeg-turbo libwebp tiff lcms2 x265 libde265 libheif

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -10,7 +10,7 @@ FROM node:${NODE_VERSION}-alpine AS base
 
 # Metadata
 ARG REPO_OWNER=thumbsup
-LABEL org.opencontainers.image.source=https://github.com/${REPO_OWNER}/thumbsup
+LABEL org.opencontainers.image.source="https://github.com/${REPO_OWNER}/thumbsup"
 
 # Add libraries
 RUN apk add --update --no-cache libgomp zlib libpng libjpeg-turbo libwebp tiff lcms2 x265 libde265 libheif

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -4,11 +4,12 @@
 # exiftool, imagemagick, ffmpeg, gifsicle...
 # -------------------------------------------------
 
-ARG NODE_VERSION
+ARG NODE_VERSION=[18, 20]
+ARG REPO_OWNER=thumbsup
 FROM node:${NODE_VERSION}-alpine as base
 
 # Metadata
-LABEL org.opencontainers.image.source https://github.com/thumbsup/thumbsup
+LABEL org.opencontainers.image.source https://github.com/${REPO_OWNER}/thumbsup
 
 # Add libraries
 RUN apk add --update --no-cache libgomp zlib libpng libjpeg-turbo libwebp tiff lcms2 x265 libde265 libheif

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -15,3 +15,6 @@ RUN apk add --update --no-cache libgomp zlib libpng libjpeg-turbo libwebp tiff l
 
 # Add external programs
 RUN apk add --update --no-cache ffmpeg imagemagick graphicsmagick exiftool gifsicle zip
+
+# Add video acceleration driver
+RUN apk add --update --no-cache intel-media-driver

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -19,4 +19,4 @@ RUN apk add --update --no-cache ffmpeg imagemagick graphicsmagick exiftool gifsi
 # Add intel video acceleration driver if x86/amd64 architecture
 RUN if [[ "${TARGETARCH}" == "amd64"]]; then \
     apk add --update --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/latest-stable/community intel-media-driver; \
-    fi
+    fi;

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -10,7 +10,8 @@ FROM node:${NODE_VERSION}-alpine AS base
 
 # Metadata
 ARG REPO_OWNER=thumbsup
-LABEL org.opencontainers.image.source=https://github.com/${REPO_OWNER}/thumbsup
+RUN echo "REPO_OWNER=${REPO_OWNER}"
+LABEL org.opencontainers.image.source https://github.com/${REPO_OWNER}/thumbsup
 
 # Add libraries
 RUN apk add --update --no-cache libgomp zlib libpng libjpeg-turbo libwebp tiff lcms2 x265 libde265 libheif

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -10,8 +10,6 @@ FROM node:${NODE_VERSION}-alpine AS base
 
 # Metadata
 ARG REPO_OWNER=thumbsup
-LABEL org.opencontainers.image.source="https://github.com/${REPO_OWNER}/thumbsup"
-LABEL org.opencontainers.image.description="Docker image for thumbsup image and video gallery"
 
 # Add libraries
 RUN apk add --update --no-cache libgomp zlib libpng libjpeg-turbo libwebp tiff lcms2 x265 libde265 libheif

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -17,4 +17,4 @@ RUN apk add --update --no-cache libgomp zlib libpng libjpeg-turbo libwebp tiff l
 RUN apk add --update --no-cache ffmpeg imagemagick graphicsmagick exiftool gifsicle zip
 
 # Add video acceleration driver
-RUN apk add --update --no-cache intel-media-driver
+RUN apk add --update --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/latest-stable/community intel-media-driver

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -5,11 +5,11 @@
 # -------------------------------------------------
 
 ARG NODE_VERSION=[18, 20]
-ARG REPO_OWNER=thumbsup
-FROM node:${NODE_VERSION}-alpine as base
+
+FROM node:${NODE_VERSION}-alpine AS base
 
 # Metadata
-LABEL "org.opencontainers.image.source"="https://github.com/${REPO_OWNER}/thumbsup"
+LABEL "org.opencontainers.image.source"="https://github.com/thumbsup/thumbsup"
 
 # Add libraries
 RUN apk add --update --no-cache libgomp zlib libpng libjpeg-turbo libwebp tiff lcms2 x265 libde265 libheif

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -5,11 +5,11 @@
 # -------------------------------------------------
 
 ARG NODE_VERSION=[18, 20]
-ARG REPO_OWNER=thumbsup
 
 FROM node:${NODE_VERSION}-alpine AS base
 
 # Metadata
+ARG REPO_OWNER=thumbsup
 RUN echo "OWNER=${REPO_OWNER}"
 LABEL org.opencontainers.image.source=https://github.com/${REPO_OWNER}/thumbsup
 

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -11,7 +11,7 @@ FROM node:${NODE_VERSION}-alpine AS base
 # Metadata
 ARG REPO_OWNER=thumbsup
 LABEL org.opencontainers.image.source="https://github.com/${REPO_OWNER}/thumbsup"
-LABEL LABEL org.opencontainers.image.description="Docker image for thumbsup image and video gallery"
+LABEL org.opencontainers.image.description="Docker image for thumbsup image and video gallery"
 
 # Add libraries
 RUN apk add --update --no-cache libgomp zlib libpng libjpeg-turbo libwebp tiff lcms2 x265 libde265 libheif

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -17,6 +17,7 @@ RUN apk add --update --no-cache libgomp zlib libpng libjpeg-turbo libwebp tiff l
 RUN apk add --update --no-cache ffmpeg imagemagick graphicsmagick exiftool gifsicle zip
 
 # Add intel video acceleration driver if x86/amd64 architecture
+ARG TARGETARCH BUILDARCH
 RUN echo "Target Arch =${TARGETARCH} and Build Arch=${BUILDARCH}"; \
     if [[ "${TARGETARCH}" == "amd64" ]]; then \
     apk add --update --no-cache --repository https://dl-cdn.alpinelinux.org/alpine/latest-stable/community intel-media-driver; \

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -11,6 +11,7 @@ FROM node:${NODE_VERSION}-alpine AS base
 # Metadata
 ARG REPO_OWNER=thumbsup
 LABEL org.opencontainers.image.source="https://github.com/${REPO_OWNER}/thumbsup"
+LABEL LABEL org.opencontainers.image.description="Docker image for thumbsup image and video gallery"
 
 # Add libraries
 RUN apk add --update --no-cache libgomp zlib libpng libjpeg-turbo libwebp tiff lcms2 x265 libde265 libheif

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -10,6 +10,7 @@ FROM node:${NODE_VERSION}-alpine AS base
 
 # Metadata
 ARG REPO_OWNER=thumbsup
+LABEL org.opencontainers.image.source="https://github.com/${REPO_OWNER}/thumbsup"
 
 # Add libraries
 RUN apk add --update --no-cache libgomp zlib libpng libjpeg-turbo libwebp tiff lcms2 x265 libde265 libheif

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -1,5 +1,5 @@
 ARG REPO_OWNER=thumbsup
-ARG NODE_VERSION=18
+ARG NODE_VERSION=20
 
 # Node.js + build dependencies + runtime dependencies
 FROM ghcr.io/${REPO_OWNER}/thumbsup/build:node-${NODE_VERSION}

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -1,5 +1,5 @@
 # Node.js + build dependencies + runtime dependencies
-FROM ghcr.io/thumbsup2/build:node-18
+FROM ghcr.io/thumbsup/build:node-18
 WORKDIR /app
 
 # Switch to a non-root user

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -1,5 +1,8 @@
+ARG REPO_OWNER=thumbsup
+ARG NODE_VERSION=18
+
 # Node.js + build dependencies + runtime dependencies
-FROM ghcr.io/thumbsup/build:node-18
+FROM ghcr.io/${REPO_OWNER}/thumbsup/build:node-${NODE_VERSION}
 WORKDIR /app
 
 # Switch to a non-root user

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -1,5 +1,5 @@
 ARG REPO_OWNER=thumbsup
-ARG NODE_VERSION=20
+ARG NODE_VERSION=18
 
 # Node.js + build dependencies + runtime dependencies
 FROM ghcr.io/${REPO_OWNER}/thumbsup/build:node-${NODE_VERSION}

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -1,5 +1,5 @@
 # Node.js + build dependencies + runtime dependencies
-FROM ghcr.io/thumbsup/build:node-18
+FROM ghcr.io/thumbsup2/build:node-18
 WORKDIR /app
 
 # Switch to a non-root user


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!
Please describe what the change is below, and don't forget to check out the CONTRIBUTING guidelines.

-->

- What's the current behavior?  The HW acceleration feature does not work in the Docker image currently due to a missing intel-media-driver package.  Also, when adding this change, I found that the current Docker build scripts/files were not setup to work well in a fork to enable testing.
- What does the PR change? Added intel-media-driver package to support HW accelerated video for the amd64 Docker image. Also, updated the github actions and Docker files to support parameters for repo-owner and other variables to enable easier testing in user forks.  In my changes, I also relocated the build and runtime intermediate docker builds under the /thumbsup project and changed the assumption that these intermediate builds are not publicly available and added logins accordingly.  I'm not a Docker expert, so if you'd prefer not to update the Docker build scripts, that's fine, the primary change is the intel package add at the bottom of the Dockerfile.runtime file. 
- Does it introduce a breaking change for existing users?
There should be no impact to users by adding the intel-media-driver package to the Docker image.  For those that use the HW acceleration (vaapi option) in the Docker image, there is a 10x improvement.  They need to ensure these two lines are in their docker run command though: 	

--device=/dev/dri/renderD128:/dev/dri/renderD128 \\
--device=/dev/dri/card0:/dev/dri/card0 \\

I did confirm that the updated Docker build scripts/Dockerfiles were working in my fork, but they should be re-run to confirm they execute properly in the main project. 