### PR TITLE
Update Dockerfile.runtime to add intel-media-driver

### DIFF
--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -15,3 +15,9 @@ RUN apk add --update --no-cache libgomp zlib libpng libjpeg-turbo libwebp tiff l
 
 # Add external programs
 RUN apk add --update --no-cache ffmpeg imagemagick graphicsmagick exiftool gifsicle zip
+
+# Add intel video acceleration driver if x86/amd64 architecture
+ARG TARGETARCH
+RUN if [[ "${TARGETARCH}" == "amd64" ]]; then \
+    apk add --update --no-cache intel-media-driver; \
+    fi;


### PR DESCRIPTION
Add missing intel-media-driver to docker file for amd64 target to enable HW acceleration for video transcoding.


<!--

Thanks for submitting a pull request!
Please describe what the change is below, and don't forget to check out the CONTRIBUTING guidelines.

-->

- What's the current behaviour? Current docker file is missing intel-media-driver for HW acceleration
- What does the PR change? Adds intel-media-driver for amd64 target docker
- Does it introduce a breaking change for existing users? Additional driver will not break existing users.
