### PR TITLE
Add AVIF image support

### DIFF
--- a/src/components/index/glob.js
+++ b/src/components/index/glob.js
@@ -2,7 +2,7 @@ const readdir = require('readdir-enhanced')
 const warn = require('debug')('thumbsup:warn')
 const GlobPattern = require('./pattern')
 
-const PHOTO_EXT = ['bmp', 'gif', 'jpg', 'jpeg', 'png', 'tif', 'tiff', 'webp', 'heic']
+const PHOTO_EXT = ['avif', 'bmp', 'gif', 'jpg', 'jpeg', 'png', 'tif', 'tiff', 'webp', 'heic']
 const VIDEO_EXT = ['3gp', 'avi', 'flv', 'm2ts', 'm4v', 'mkv', 'mp4', 'mpg', 'mpeg', 'mov', 'mts', 'ogg', 'ogv', 'webm', 'wmv']
 const RAW_PHOTO_EXT = [
   '3fr', 'arw', 'cr2', 'crw', 'dcr', 'dng', 'erf', 'k25', 'kdc',


### PR DESCRIPTION
This adds `AVIF` image support
No tests are written for HEIC so I did not bother trying to write one for  `AVIF`