### PR TITLE
#390 - Add XMP namespace to embedded exif data

### DIFF
--- a/src/model/metadata.js
+++ b/src/model/metadata.js
@@ -35,7 +35,7 @@ class Metadata {
     const size = dimensions(exiftool)
     this.width = size.width
     this.height = size.height
-    this.exif = opts ? (opts.embedExif ? exiftool.EXIF : undefined) : undefined
+    this.exif = opts ? (opts.embedExif ? {...exiftool.EXIF, 'XMP': exiftool.XMP} : undefined) : undefined
     // metadata could also include fields like
     //  - lat = 51.5
     //  - long = 0.12


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!
Please describe what the change is below, and don't forget to check out the CONTRIBUTING guidelines.

-->
Fixes #390 

** Current behavior
Currently, namespaces in the file's embedded metadata other than EXIF are not processed and thus not available for generating albums when customizing album creation.  

** Changes introduced by PR
Adds the XMP namespace to the EXIF data if (and only if) embedExif is true.

As an example use case, my filter.js which I'm using to produce albums based on the more structured hierarchical keywords used by Darktable and Digikam.

```javascript
module.exports = (file) => {
  let albums = ['All Pics'];
  if (file.meta.keywords.includes('Dog')) {
    for (let kw of file.meta.exif.XMP.HierarchicalSubject) {
      if(kw.startsWith('Animal|Dog|')) {
        albums.push(kw.slice(11));
      }
    }
    return albums;
  }
}
```

** Does it introduce a breaking change for existing users?
No, this should be completely transparent to existing users.