### PR TITLE
Custom code for album preview selection

### DIFF
--- a/src/cli/options.js
+++ b/src/cli/options.js
@@ -284,7 +284,8 @@ const OPTIONS = {
   'album-previews': {
     group: 'Album options:',
     description: 'How previews are selected',
-    choices: ['first', 'spread', 'random'],
+    type: 'string',
+    //choices: ['first', 'spread', 'random'],
     'default': 'first'
   },
 

--- a/src/model/album.js
+++ b/src/model/album.js
@@ -141,7 +141,13 @@ Album.prototype.pickPreviews = function (options) {
       const buckets = _.chunk(potential, bucketSize)
       this.previews = buckets.slice(0, PREVIEW_COUNT).map(b => b[0])
     }
-  } else {
+  } else if ( options.albumPreviews.startsWith('file://')) {
+    const filepath = options.albumPreviews.slice('file://'.length)
+    this.previews = require(path.resolve(filepath))(potential, PREVIEW_COUNT)
+  }
+
+
+  else {
     throw new Error(`Unsupported preview type: ${options.albumPreviews}`)
   }
 


### PR DESCRIPTION
<!--

Thanks for submitting a pull request!
Please describe what the change is below, and don't forget to check out the CONTRIBUTING guidelines.

-->
Addresses #393 
** Current behaviour
Currently, preview selection is limited to a set of choices: first, random, and spread
 
** Changes` introduced by PR
This change allows for custom code to be used for selection of which images to use for generating previews for albums.  It works similarly to the `albums-from` argument, changing the `album-previews` argument to take a `file://` url and defer to custom code in that file.

** Does it introduce a breaking change for existing users?
It does not break existing code.  Arguably, it makes the error slightly more opaque for users who put in something wrong, since `choices` is more specific than `string`, but it will not break any existing workflow using correct values. 